### PR TITLE
attempt to make token agnostic versions of sdk

### DIFF
--- a/packages/react/src/hooks/token/useSuckersTokenBalance.ts
+++ b/packages/react/src/hooks/token/useSuckersTokenBalance.ts
@@ -17,7 +17,7 @@ import { useSuckers } from "../suckers/useSuckers";
 /**
  * Return the current surplus of JB Native token across each sucker on all chains for the current project.
  */
-export function useSuckersTokenBalance(token: Token) {
+export function useSuckersTokenBalance(tokens: Record<number, Token>) {
   const config = useConfig();
 
   const chainId = useJBChainId();
@@ -46,6 +46,7 @@ export function useSuckersTokenBalance(token: Token) {
       const balances = await Promise.all(
         pairs.map(async (pair) => {
           const { peerChainId, projectId } = pair;
+          const token = tokens[peerChainId];
           const [terminal, store] = await Promise.all([
             readJbDirectoryPrimaryTerminalOf(config, {
               chainId: Number(peerChainId) as JBChainId,

--- a/packages/react/src/hooks/token/useSuckersTokenBalance.ts
+++ b/packages/react/src/hooks/token/useSuckersTokenBalance.ts
@@ -1,0 +1,78 @@
+import {
+    getProjectTerminalStore,
+    readJbDirectoryPrimaryTerminalOf,
+    readJbTerminalStoreBalanceOf,
+    Token
+} from "juice-sdk-core";
+import { zeroAddress } from "viem";
+import { useConfig } from "wagmi";
+import { useQuery } from "wagmi/query";
+import {
+    JBChainId,
+    useJBChainId,
+} from "../../contexts/JBChainContext/JBChainContext";
+import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
+import { useSuckers } from "../suckers/useSuckers";
+
+/**
+ * Return the current surplus of JB Native token across each sucker on all chains for the current project.
+ */
+export function useSuckersTokenBalance(token: Token) {
+  const config = useConfig();
+
+  const chainId = useJBChainId();
+  const { projectId } = useJBContractContext();
+
+  const suckersQuery = useSuckers();
+  const pairs = suckersQuery.data;
+
+  const balanceQuery = useQuery({
+    queryKey: [
+      "suckersNativeTokenBalance",
+      projectId.toString(),
+      chainId?.toString(),
+      pairs?.map((pair) => pair.peerChainId).join(","),
+    ],
+    queryFn: async () => {
+      if (!chainId) return null;
+
+      if (!pairs || pairs.length === 0) {
+        return [];
+      }
+
+      /**
+       * For each peer, get its terminal, then get the current surplus.
+       */
+      const balances = await Promise.all(
+        pairs.map(async (pair) => {
+          const { peerChainId, projectId } = pair;
+          const [terminal, store] = await Promise.all([
+            readJbDirectoryPrimaryTerminalOf(config, {
+              chainId: Number(peerChainId) as JBChainId,
+              args: [projectId, token],
+            }), // TODO should probably be api'd and cached one day
+            getProjectTerminalStore(config, peerChainId, projectId),
+          ]);
+
+          const balance = await readJbTerminalStoreBalanceOf(config, {
+            chainId: Number(peerChainId) as JBChainId,
+            address: store,
+            args: [terminal ?? zeroAddress, projectId, token],
+          });
+
+          return { balance, chainId: peerChainId, projectId };
+        })
+      );
+
+      return balances;
+    },
+  });
+
+  return {
+    isLoading: balanceQuery.isLoading || suckersQuery.isLoading,
+    isError: balanceQuery.isError || suckersQuery.isError,
+    data: balanceQuery.data as
+      | { balance: bigint; chainId: number; projectId: bigint }[]
+      | undefined,
+  };
+}

--- a/packages/react/src/hooks/token/useSuckersTokenSurplus.ts
+++ b/packages/react/src/hooks/token/useSuckersTokenSurplus.ts
@@ -1,0 +1,85 @@
+import {
+  Token,
+  Currency,
+  readJbDirectoryPrimaryTerminalOf,
+  readJbMultiTerminalCurrentSurplusOf,
+} from "juice-sdk-core";
+import { useConfig } from "wagmi";
+import { useQuery } from "wagmi/query";
+import {
+  JBChainId,
+  useJBChainId,
+} from "../../contexts/JBChainContext/JBChainContext";
+import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
+import { useSuckers } from "../suckers/useSuckers";
+
+/**
+ * Return the current surplus of JB Native token across each sucker on all chains for the current project.
+ */
+export function useSuckersTokenSurplus(token: Token, currency: Currency, decimals: number, inTermsOfCurrency: Currency, inTermsOfDecimals: number) {
+  const config = useConfig();
+
+  const chainId = useJBChainId();
+  const { projectId } = useJBContractContext();
+
+  const suckersQuery = useSuckers();
+  const pairs = suckersQuery.data;
+
+  const surplusQuery = useQuery({
+    queryKey: [
+      "suckersTokenSurplus",
+      projectId.toString(),
+      chainId?.toString(),
+      pairs?.map((pair) => pair.peerChainId).join(","),
+    ],
+    queryFn: async () => {
+      if (!chainId) return null;
+
+      if (!pairs || pairs.length === 0) {
+        return [];
+      }
+
+      /**
+       * For each peer, get its terminal, then get the current surplus.
+       */
+      const surpluses = await Promise.all(
+        pairs.map(async (pair) => {
+          const { peerChainId, projectId } = pair;
+          const terminal = await readJbDirectoryPrimaryTerminalOf(config, {
+            chainId: Number(peerChainId) as JBChainId,
+            args: [projectId, token],
+          });
+
+          const surplus = await readJbMultiTerminalCurrentSurplusOf(config, {
+            chainId: Number(peerChainId) as JBChainId,
+            address: terminal,
+            args: [
+              projectId,
+              [
+                {
+                  token: token,
+                  decimals: decimals,
+                  currency: currency,
+                },
+              ],
+              BigInt(inTermsOfDecimals),
+              BigInt(inTermsOfCurrency),
+            ],
+          });
+
+          return { surplus, chainId: peerChainId, projectId };
+        })
+      );
+
+      return surpluses;
+    },
+  });
+
+  return {
+    isLoading: surplusQuery.isLoading || suckersQuery.isLoading,
+    isError: surplusQuery.isError || suckersQuery.isError,
+    data: surplusQuery.data as
+      | { surplus: bigint; chainId: JBChainId; projectId: bigint }[]
+      | undefined,
+  };
+}

--- a/packages/react/src/hooks/token/useTokenSurplus.ts
+++ b/packages/react/src/hooks/token/useTokenSurplus.ts
@@ -1,0 +1,44 @@
+import {
+  JBChainId,
+  Token,
+  Currency,
+} from "juice-sdk-core";
+import { useJBChainId } from "../../contexts/JBChainContext/JBChainContext";
+import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
+import { useReadJbMultiTerminalCurrentSurplusOf } from "../../generated/juicebox";
+
+/**
+ * Return the current surplus of JB Native token, from the project's primary native terminal.
+ */
+export function useTokenSurplus({
+  chainId,
+  token,
+  currency,
+  decimals,
+  inTermsOfCurrency,
+  inTermsOfDecimals,
+}: { chainId?: JBChainId; token?: Token, currency?: Currency, decimals?: number, inTermsOfCurrency?: Currency, inTermsOfDecimals?: number } = {}) {
+  const {
+    projectId,
+    contracts: { primaryNativeTerminal },
+  } = useJBContractContext();
+
+  const _chainId = chainId ?? useJBChainId();
+
+  return useReadJbMultiTerminalCurrentSurplusOf({
+    chainId: _chainId,
+    address: primaryNativeTerminal.data ?? undefined,
+    args: [
+      projectId,
+      [
+        {
+          token: token,
+          decimals: decimals,
+          currency: currency,
+        },
+      ],
+      BigInt(inTermsOfDecimals),
+      BigInt(inTermsOfCurrency),
+    ],
+  });
+}

--- a/packages/react/src/hooks/token/useTokenSurplus.ts
+++ b/packages/react/src/hooks/token/useTokenSurplus.ts
@@ -37,8 +37,8 @@ export function useTokenSurplus({
           currency: currency,
         },
       ],
-      BigInt(inTermsOfDecimals),
-      BigInt(inTermsOfCurrency),
+      BigInt(inTermsOfDecimals ?? 0),
+      BigInt(inTermsOfCurrency ?? 0),
     ],
   });
 }


### PR DESCRIPTION
An attempt to make token agnostic versions of a few SDKs.

Added `useSuckersTokenBalance`, `useSuckersTokenSurplus`, and `useTokenSurplus`.


Keep in mind the same token can have different addresses on different chains. i.e. USDC.
