### PR TITLE
Rename packages to @bananapus/nana-sdk-core and @bananapus/nana-sdk-react

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Juice SDK v4
 
-[![npm version](https://img.shields.io/npm/v/juice-sdk-core.svg)](https://www.npmjs.com/package/juice-sdk-core)
-[![npm version](https://img.shields.io/npm/v/juice-sdk-react.svg)](https://www.npmjs.com/package/juice-sdk-react)
+[![npm version](https://img.shields.io/npm/v/@bananapus/nana-sdk-core.svg)](https://www.npmjs.com/package/@bananapus/nana-sdk-core)
+[![npm version](https://img.shields.io/npm/v/@bananapus/nana-sdk-react.svg)](https://www.npmjs.com/package/@bananapus/nana-sdk-react)
 
 A JavaScript SDK for building applications on the [Juicebox protocol](https://docs.juicebox.money/) (V4, V5, and V6).
 
@@ -9,10 +9,10 @@ A JavaScript SDK for building applications on the [Juicebox protocol](https://do
 
 ```bash
 # For React applications
-npm install juice-sdk-react juice-sdk-core
+npm install @bananapus/nana-sdk-react @bananapus/nana-sdk-core
 
 # For vanilla JavaScript/Node.js
-npm install juice-sdk-core
+npm install @bananapus/nana-sdk-core
 
 # For Revnet-specific functionality
 npm install revnet-sdk
@@ -23,8 +23,8 @@ npm install revnet-sdk
 ### React Application
 
 ```tsx
-import { JBProjectProvider, useJBRuleset, useTokenCashOutQuoteEth } from "juice-sdk-react";
-import { formatTokenAmount } from "juice-sdk-core";
+import { JBProjectProvider, useJBRuleset, useTokenCashOutQuoteEth } from "@bananapus/nana-sdk-react";
+import { formatTokenAmount } from "@bananapus/nana-sdk-core";
 
 function ProjectDashboard() {
   const projectId = 1n;
@@ -66,7 +66,7 @@ import {
   parseTokenAmount,
   ReservedPercent,
   CashOutTaxRate,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 
 // Format token amounts for display
 const formatted = formatTokenAmount(1000000000000000000n); // "1.0"
@@ -80,8 +80,8 @@ const taxRate = new CashOutTaxRate(2.5); // 2.5% cash out tax
 
 | Package                               | Description                                       | NPM                                                                                                       |
 | ------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| [`juice-sdk-core`](./packages/core)   | Core utilities, contract bindings, and data types | [![npm](https://img.shields.io/npm/v/juice-sdk-core.svg)](https://www.npmjs.com/package/juice-sdk-core)   |
-| [`juice-sdk-react`](./packages/react) | React hooks, contexts, and components             | [![npm](https://img.shields.io/npm/v/juice-sdk-react.svg)](https://www.npmjs.com/package/juice-sdk-react) |
+| [`@bananapus/nana-sdk-core`](./packages/core)   | Core utilities, contract bindings, and data types | [![npm](https://img.shields.io/npm/v/@bananapus/nana-sdk-core.svg)](https://www.npmjs.com/package/@bananapus/nana-sdk-core)   |
+| [`@bananapus/nana-sdk-react`](./packages/react) | React hooks, contexts, and components             | [![npm](https://img.shields.io/npm/v/@bananapus/nana-sdk-react.svg)](https://www.npmjs.com/package/@bananapus/nana-sdk-react) |
 | [`revnet-sdk`](./packages/revnet)     | Revnet protocol utilities and hooks               | [![npm](https://img.shields.io/npm/v/revnet-sdk.svg)](https://www.npmjs.com/package/revnet-sdk)           |
 
 ### Core Package Features
@@ -115,7 +115,7 @@ See https://docs.juicebox.money to learn more.
 Juicebox contracts use fixed-point math for precision. The SDK provides helper classes:
 
 ```javascript
-import { ReservedPercent, CashOutTaxRate, RulesetWeight } from "juice-sdk-core";
+import { ReservedPercent, CashOutTaxRate, RulesetWeight } from "@bananapus/nana-sdk-core";
 
 // Create percentage values
 const reserved = new ReservedPercent(15); // 15%

--- a/package-lock.json
+++ b/package-lock.json
@@ -684,6 +684,14 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@bananapus/nana-sdk-core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@bananapus/nana-sdk-react": {
+      "resolved": "packages/react",
+      "link": true
+    },
     "node_modules/@bananapus/omnichain-deployers": {
       "version": "1.0.3",
       "resolved": "git+ssh://git@github.com/bananapus/nana-omnichain-deployers.git#42d39e1442cba9e916ad812112755629711fb759",
@@ -9452,7 +9460,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9469,7 +9476,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9486,7 +9492,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9503,7 +9508,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9520,7 +9524,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9537,7 +9540,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9554,7 +9556,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9571,7 +9572,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9588,7 +9588,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9605,7 +9604,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -16823,14 +16821,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/juice-sdk-core": {
-      "resolved": "packages/core",
-      "link": true
-    },
-    "node_modules/juice-sdk-react": {
-      "resolved": "packages/react",
-      "link": true
-    },
     "node_modules/just-extend": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
@@ -23503,8 +23493,8 @@
       }
     },
     "packages/core": {
-      "name": "juice-sdk-core",
-      "version": "3.0.0-dev.0",
+      "name": "@bananapus/nana-sdk-core",
+      "version": "1.0.0",
       "dependencies": {
         "bs58": "^5.0.0",
         "fpnum": "^1.0.0"
@@ -24232,13 +24222,14 @@
       }
     },
     "packages/react": {
-      "name": "juice-sdk-react",
-      "version": "6.0.0-dev.0",
+      "name": "@bananapus/nana-sdk-react",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "graphql-request": "^7.2.0"
       },
       "devDependencies": {
+        "@bananapus/nana-sdk-core": "*",
         "@graphql-codegen/cli": "^5.0.2",
         "@graphql-codegen/client-preset": "^4.3.0",
         "@graphql-codegen/introspection": "^4.0.3",
@@ -24247,7 +24238,6 @@
         "@tanstack/react-query": "^5.0.0",
         "@types/react": "^19.1.13",
         "change-case": "^5.4.4",
-        "juice-sdk-core": "*",
         "react": "^18.3.1",
         "tsup": "^8.1.0",
         "viem": "^2.14.1",
@@ -24255,8 +24245,8 @@
         "wagmi": "^2.10.2"
       },
       "peerDependencies": {
+        "@bananapus/nana-sdk-core": "*",
         "@tanstack/react-query": "^5.0.0",
-        "juice-sdk-core": "*",
         "react": "^18.3.1",
         "viem": "^2.14.1",
         "wagmi": "^2.10.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "juice-sdk-core",
-  "version": "3.0.0",
+  "name": "@bananapus/nana-sdk-core",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "generate": "wagmi generate",

--- a/packages/core/src/actions/dataHook.ts
+++ b/packages/core/src/actions/dataHook.ts
@@ -24,7 +24,7 @@ export async function find721DataHook(
 ) {
   const chainId = publicClient.chain?.id;
   if (!chainId) {
-    throw new Error("[juice-sdk-core] No chain ID on public client.");
+    throw new Error("[@bananapus/nana-sdk-core] No chain ID on public client.");
   }
 
   const deployerAddress = getJBContractAddress(
@@ -40,7 +40,7 @@ export async function find721DataHook(
   );
 
   if (!registerAddress) {
-    throw new Error(`[juice-sdk-core] No JBAddressRegistry address for chain ${chainId}.`);
+    throw new Error(`[@bananapus/nana-sdk-core] No JBAddressRegistry address for chain ${chainId}.`);
   }
 
   const registry = getContract({

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,13 +1,13 @@
-# juice-sdk-react
+# @bananapus/nana-sdk-react
 
 [Wagmi](https://wagmi.sh/) hooks for Juicebox. Useful data contexts and helpers for building React applications.
 
 ## Installation
 
-Install the `juice-sdk-react` for React, and it's peer dependency, `juice-sdk-core`.
+Install the `@bananapus/nana-sdk-react` for React, and it's peer dependency, `@bananapus/nana-sdk-core`.
 
 ```
-npm install juice-sdk-react juice-sdk-core
+npm install @bananapus/nana-sdk-react @bananapus/nana-sdk-core
 ```
 
 ## Usage
@@ -22,7 +22,7 @@ Fetching all of the commonly used data for Juicebox projects can be cumbersome. 
 `JBProjectProvider` is used in the following example:
 
 ```tsx
-import { JBProjectProvider } from "juice-sdk-react";
+import { JBProjectProvider } from "@bananapus/nana-sdk-react";
 
 function MyPage() {
   const projectId = 1n;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "juice-sdk-react",
-  "version": "6.0.0",
+  "name": "@bananapus/nana-sdk-react",
+  "version": "1.0.0",
   "description": "Wagmi hooks for Juicebox",
   "type": "module",
   "scripts": {
     "test": "vitest run",
     "generate-gql": "graphql-code-generator --config codegen.yml -r",
-    "generate-types": "echo '🔧 Generating types...' && tsc --emitDeclarationOnly",
+    "generate-types": "echo '\ud83d\udd27 Generating types...' && tsc --emitDeclarationOnly",
     "prebuild": "rm -Rf dist",
     "build": "tsup && npm run generate-types",
     "dev": "tsup --watch",
@@ -16,10 +16,10 @@
   "license": "ISC",
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
-    "juice-sdk-core": "*",
     "react": "^18.3.1",
     "viem": "^2.14.1",
-    "wagmi": "^2.10.2"
+    "wagmi": "^2.10.2",
+    "@bananapus/nana-sdk-core": "*"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.2",
@@ -30,12 +30,12 @@
     "@tanstack/react-query": "^5.0.0",
     "@types/react": "^19.1.13",
     "change-case": "^5.4.4",
-    "juice-sdk-core": "*",
     "react": "^18.3.1",
     "tsup": "^8.1.0",
     "viem": "^2.14.1",
     "vitest": "^3.2.4",
-    "wagmi": "^2.10.2"
+    "wagmi": "^2.10.2",
+    "@bananapus/nana-sdk-core": "*"
   },
   "files": [
     "dist/**/*"

--- a/packages/react/src/components/NativeTokenValue.tsx
+++ b/packages/react/src/components/NativeTokenValue.tsx
@@ -1,4 +1,4 @@
-import { NATIVE_TOKEN_DECIMALS, formatUnits } from "juice-sdk-core";
+import { NATIVE_TOKEN_DECIMALS, formatUnits } from "@bananapus/nana-sdk-core";
 import { useNativeTokenSymbol } from "../hooks/token/useNativeTokenSymbol";
 
 /**

--- a/packages/react/src/contexts/JBChainContext/JBChainContext.tsx
+++ b/packages/react/src/contexts/JBChainContext/JBChainContext.tsx
@@ -1,4 +1,4 @@
-import { debug, JBChainId } from "juice-sdk-core";
+import { debug, JBChainId } from "@bananapus/nana-sdk-core";
 import { createContext, PropsWithChildren, useContext } from "react";
 
 /**

--- a/packages/react/src/contexts/JBContractContext/JBContractContext.tsx
+++ b/packages/react/src/contexts/JBContractContext/JBContractContext.tsx
@@ -10,7 +10,7 @@ import {
   JBCoreContracts,
   getJBContractAddress,
   Contract,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { PropsWithChildren, createContext, useCallback, useContext, useMemo } from "react";
 import { Address, isAddressEqual, zeroAddress } from "viem";
 import { useSuckers } from "../../hooks";

--- a/packages/react/src/contexts/JBDataHookContext/JBCurrentDataHookProvider.tsx
+++ b/packages/react/src/contexts/JBDataHookContext/JBCurrentDataHookProvider.tsx
@@ -1,4 +1,4 @@
-import { debug } from "juice-sdk-core";
+import { debug } from "@bananapus/nana-sdk-core";
 import { useJBRulesetMetadata } from "../JBRulesetContext/JBRulesetContext";
 import { JBDataHookProvider } from "./JBDataHookContext";
 

--- a/packages/react/src/contexts/JBDataHookContext/JBDataHookContext.tsx
+++ b/packages/react/src/contexts/JBDataHookContext/JBDataHookContext.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren, createContext, useContext, useMemo } from "react";
 import { Address } from "viem";
 import { AsyncData, AsyncDataNone } from "../types";
-import { debug } from "juice-sdk-core";
+import { debug } from "@bananapus/nana-sdk-core";
 
 /**
  * Data structure for the context for a given dataHook.

--- a/packages/react/src/contexts/JBProjectMetadataContext/JBProjectMetadataContext.tsx
+++ b/packages/react/src/contexts/JBProjectMetadataContext/JBProjectMetadataContext.tsx
@@ -1,4 +1,4 @@
-import { JBProjectMetadata, debug, getProjectMetadata } from "juice-sdk-core";
+import { JBProjectMetadata, debug, getProjectMetadata } from "@bananapus/nana-sdk-core";
 import { createContext, useContext } from "react";
 import { Address } from "viem";
 import { usePublicClient } from "wagmi";

--- a/packages/react/src/contexts/JBProjectProvider/JBProjectProvider.tsx
+++ b/packages/react/src/contexts/JBProjectProvider/JBProjectProvider.tsx
@@ -12,7 +12,7 @@ import {
 import { JBRulesetProvider } from "../JBRulesetContext/JBRulesetContext";
 import { JBTokenProvider, JBTokenProviderProps } from "../JBTokenContext/JBTokenContext";
 import { JBPrimaryNativeTerminalProvider } from "../JBTerminalContext/JBPrimaryNativeTerminalProvider";
-import { JBChainId, JBVersion } from "juice-sdk-core";
+import { JBChainId, JBVersion } from "@bananapus/nana-sdk-core";
 import { BendystrawConfig } from "../../lib/bendystraw/getBendystrawUrl";
 
 type JBProjectProviderProps = PropsWithChildren<{

--- a/packages/react/src/contexts/JBRulesetContext/JBRulesetContext.tsx
+++ b/packages/react/src/contexts/JBRulesetContext/JBRulesetContext.tsx
@@ -5,7 +5,7 @@ import {
   ReservedPercent,
   RulesetWeight,
   WeightCutPercent,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { createContext, useContext } from "react";
 import { ContractFunctionReturnType } from "viem";
 import { useReadContract } from "wagmi";

--- a/packages/react/src/contexts/JBTerminalContext/JBPrimaryNativeTerminalProvider.tsx
+++ b/packages/react/src/contexts/JBTerminalContext/JBPrimaryNativeTerminalProvider.tsx
@@ -1,4 +1,4 @@
-import { debug } from "juice-sdk-core";
+import { debug } from "@bananapus/nana-sdk-core";
 import { useJBContractContext } from "../JBContractContext/JBContractContext";
 import { JBTerminalProvider } from "./JBTerminalContext";
 

--- a/packages/react/src/contexts/JBTerminalContext/JBTerminalContext.tsx
+++ b/packages/react/src/contexts/JBTerminalContext/JBTerminalContext.tsx
@@ -1,4 +1,4 @@
-import { jbMultiTerminalAbi } from "juice-sdk-core";
+import { jbMultiTerminalAbi } from "@bananapus/nana-sdk-core";
 import { PropsWithChildren, createContext, useContext } from "react";
 import { Address, ContractFunctionReturnType, isAddressEqual, zeroAddress } from "viem";
 import { useJBChainId } from "../JBChainContext/JBChainContext";

--- a/packages/react/src/contexts/JBTokenContext/JBTokenContext.tsx
+++ b/packages/react/src/contexts/JBTokenContext/JBTokenContext.tsx
@@ -4,7 +4,7 @@ import {
   JBCoreContracts,
   JBProjectToken,
   jbTokensAbi,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { createContext, PropsWithChildren, useContext } from "react";
 import { isAddressEqual, zeroAddress } from "viem";
 import { useReadContract, useToken, UseTokenReturnType } from "wagmi";

--- a/packages/react/src/hooks/jb721Hook/use721HookMetadataId.tsx
+++ b/packages/react/src/hooks/jb721Hook/use721HookMetadataId.tsx
@@ -1,7 +1,7 @@
 import { useJBChainId } from "../../contexts/JBChainContext/JBChainContext";
 import { Address } from "viem";
 import { createMetadataTargetIdPayHash } from "./helpers";
-import { jb721TiersHookAbi } from "juice-sdk-core";
+import { jb721TiersHookAbi } from "@bananapus/nana-sdk-core";
 import { useReadContract } from "wagmi";
 
 /**

--- a/packages/react/src/hooks/jb721Hook/useFind721DataHook.tsx
+++ b/packages/react/src/hooks/jb721Hook/useFind721DataHook.tsx
@@ -1,10 +1,10 @@
-import { find721DataHook } from "juice-sdk-core";
+import { find721DataHook } from "@bananapus/nana-sdk-core";
 import { usePublicClient } from "wagmi";
 import { useQuery } from "wagmi/query";
 import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
 import { useJBRulesetContext } from "../../contexts/JBRulesetContext/JBRulesetContext";
 import { useJBDataHookContext } from "../../contexts/JBDataHookContext/JBDataHookContext";
-import { debug } from "juice-sdk-core";
+import { debug } from "@bananapus/nana-sdk-core";
 
 /**
  * Return the 721 data hook (if it exists) for the project and current ruleset in context.

--- a/packages/react/src/hooks/ruleset/useJBRuleset.ts
+++ b/packages/react/src/hooks/ruleset/useJBRuleset.ts
@@ -5,7 +5,7 @@ import {
   ReservedPercent,
   RulesetWeight,
   WeightCutPercent,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { useReadContract } from "wagmi";
 import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
 import { useResolveDataHook } from "./useResolveDataHook";

--- a/packages/react/src/hooks/ruleset/useJBUpcomingRuleset.ts
+++ b/packages/react/src/hooks/ruleset/useJBUpcomingRuleset.ts
@@ -7,7 +7,7 @@ import {
   ReservedPercent,
   RulesetWeight,
   WeightCutPercent,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { useReadContract } from "wagmi";
 import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
 import { useResolveDataHook } from "./useResolveDataHook";

--- a/packages/react/src/hooks/ruleset/useResolveDataHook.ts
+++ b/packages/react/src/hooks/ruleset/useResolveDataHook.ts
@@ -4,7 +4,7 @@ import {
   jbOmnichainDeployer4_1Abi,
   jbOmnichainDeployerAbi,
   jbOmnichainDeployerV5Abi,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
 import { isAddressEqual, zeroAddress } from "viem";
 import { mainnet } from "viem/chains";

--- a/packages/react/src/hooks/suckers/useSuckers.ts
+++ b/packages/react/src/hooks/suckers/useSuckers.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { debug, JBChainId } from "juice-sdk-core";
+import { debug, JBChainId } from "@bananapus/nana-sdk-core";
 import { ProjectDocument } from "src/generated/graphql";
 import { useBendystrawQuery } from "src/lib/bendystraw/useBendystrawQuery";
 import {

--- a/packages/react/src/hooks/token/useNativeTokenSurplus.ts
+++ b/packages/react/src/hooks/token/useNativeTokenSurplus.ts
@@ -5,7 +5,7 @@ import {
   jbMultiTerminalV5Abi,
   NATIVE_TOKEN,
   NATIVE_TOKEN_DECIMALS,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { useJBChainId } from "../../contexts/JBChainContext/JBChainContext";
 import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
 import { useReadContract } from "wagmi";

--- a/packages/react/src/hooks/token/useNativeTokenSymbol.ts
+++ b/packages/react/src/hooks/token/useNativeTokenSymbol.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_NATIVE_TOKEN_SYMBOL, JB_CHAINS, JBChainId } from "juice-sdk-core";
+import { DEFAULT_NATIVE_TOKEN_SYMBOL, JB_CHAINS, JBChainId } from "@bananapus/nana-sdk-core";
 import { useJBChainId } from "../../contexts/JBChainContext/JBChainContext";
 
 /**

--- a/packages/react/src/hooks/token/useSuckersCashOutQuote.ts
+++ b/packages/react/src/hooks/token/useSuckersCashOutQuote.ts
@@ -7,7 +7,7 @@ import {
   jbTerminalStoreV5Abi,
   JBVersion,
   NATIVE_TOKEN_DECIMALS,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { getContract } from "viem";
 import { useConfig } from "wagmi";
 import { useQuery, UseQueryReturnType } from "wagmi/query";

--- a/packages/react/src/hooks/token/useSuckersNativeTokenBalance.ts
+++ b/packages/react/src/hooks/token/useSuckersNativeTokenBalance.ts
@@ -3,7 +3,7 @@ import {
   getProjectTerminalStore,
   jbTerminalStoreAbi,
   NATIVE_TOKEN,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { getContract } from "viem";
 import { useConfig } from "wagmi";
 import { useQuery } from "wagmi/query";

--- a/packages/react/src/hooks/token/useSuckersNativeTokenSurplus.ts
+++ b/packages/react/src/hooks/token/useSuckersNativeTokenSurplus.ts
@@ -6,7 +6,7 @@ import {
   jbMultiTerminalV5Abi,
   NATIVE_TOKEN,
   NATIVE_TOKEN_DECIMALS,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { getContract } from "viem";
 import { useConfig } from "wagmi";
 import { useQuery } from "wagmi/query";

--- a/packages/react/src/hooks/token/useSuckersTokenCashOutValue.ts
+++ b/packages/react/src/hooks/token/useSuckersTokenCashOutValue.ts
@@ -1,4 +1,4 @@
-import { ONE_JB_TOKEN } from "juice-sdk-core";
+import { ONE_JB_TOKEN } from "@bananapus/nana-sdk-core";
 import { formatEther } from "viem";
 import { useEtherPrice } from "../useEtherPrice";
 import { useSuckersCashOutQuote } from "./useSuckersCashOutQuote";

--- a/packages/react/src/hooks/token/useSuckersUserTokenBalance.ts
+++ b/packages/react/src/hooks/token/useSuckersUserTokenBalance.ts
@@ -1,4 +1,4 @@
-import { JBChainId, JBCoreContracts, JBProjectToken, jbTokensAbi } from "juice-sdk-core";
+import { JBChainId, JBCoreContracts, JBProjectToken, jbTokensAbi } from "@bananapus/nana-sdk-core";
 import { getContract } from "viem";
 import { useAccount, useConfig, useReadContract } from "wagmi";
 import { useQuery } from "wagmi/query";

--- a/packages/react/src/hooks/token/useTokenCashOutQuoteEth.ts
+++ b/packages/react/src/hooks/token/useTokenCashOutQuoteEth.ts
@@ -5,7 +5,7 @@ import {
   applyJbDaoCashOutFee,
   jbTerminalStoreAbi,
   jbTerminalStoreV5Abi,
-} from "juice-sdk-core";
+} from "@bananapus/nana-sdk-core";
 import { useJBChainId } from "../../contexts/JBChainContext/JBChainContext";
 import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
 import { useJBTerminalContext } from "../../contexts/JBTerminalContext/JBTerminalContext";

--- a/packages/react/src/hooks/usePreparePayMetadata.ts
+++ b/packages/react/src/hooks/usePreparePayMetadata.ts
@@ -1,8 +1,8 @@
 "use client";
-import { DEFAULT_ALLOW_OVERSPENDING, createHookMetadata } from "juice-sdk-core";
+import { DEFAULT_ALLOW_OVERSPENDING, createHookMetadata } from "@bananapus/nana-sdk-core";
 import { Address, Hash, encodeAbiParameters } from "viem";
 import { use721HookMetadataId } from "./jb721Hook/use721HookMetadataId";
-import { debug } from "juice-sdk-core";
+import { debug } from "@bananapus/nana-sdk-core";
 
 interface Jb721HookPayMetadata {
   tierIdsToMint: bigint[];

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
-export type { JBChainId, JBVersion } from "juice-sdk-core";
+export type { JBChainId, JBVersion } from "@bananapus/nana-sdk-core";
 export * from "./components/NativeTokenValue";
 export * from "./contexts/JBChainContext/JBChainContext";
 export * from "./contexts/JBContractContext/JBContractContext";

--- a/packages/react/src/lib/relayr/hooks/useGetRelayrTxQuote.ts
+++ b/packages/react/src/lib/relayr/hooks/useGetRelayrTxQuote.ts
@@ -1,4 +1,4 @@
-import { JBChainId, JBVersion } from "juice-sdk-core";
+import { JBChainId, JBVersion } from "@bananapus/nana-sdk-core";
 import { useRequestRelayrQuote } from "./useRequestRelayrQuote";
 import {
   ERC2771ForwardRequestData,

--- a/packages/react/src/lib/relayr/hooks/useRequestRelayrQuote.ts
+++ b/packages/react/src/lib/relayr/hooks/useRequestRelayrQuote.ts
@@ -1,5 +1,5 @@
 "use client";
-import { JBChainId, JBVersion, jbContractAddress } from "juice-sdk-core";
+import { JBChainId, JBVersion, jbContractAddress } from "@bananapus/nana-sdk-core";
 import { useJBContractContext } from "../../../contexts/JBContractContext/JBContractContext";
 import { useMutation } from "wagmi/query";
 import { API } from "../constants";

--- a/packages/react/src/lib/relayr/hooks/useSignErc2771ForwardRequest.ts
+++ b/packages/react/src/lib/relayr/hooks/useSignErc2771ForwardRequest.ts
@@ -1,4 +1,4 @@
-import { JBChainId, JBVersion, erc2771ForwarderAbi, jbContractAddress } from "juice-sdk-core";
+import { JBChainId, JBVersion, erc2771ForwarderAbi, jbContractAddress } from "@bananapus/nana-sdk-core";
 import { useJBContractContext } from "../../../contexts/JBContractContext/JBContractContext";
 import { Address, Hash, encodeFunctionData, getContract } from "viem";
 import { useAccount, useConfig, useSignTypedData, useSwitchChain } from "wagmi";

--- a/packages/react/src/lib/relayr/types.ts
+++ b/packages/react/src/lib/relayr/types.ts
@@ -1,4 +1,4 @@
-import { JBChainId } from "juice-sdk-core";
+import { JBChainId } from "@bananapus/nana-sdk-core";
 import { Hash } from "viem";
 
 export type ChainPayment = {


### PR DESCRIPTION
## Summary

The `juice-sdk-core` / `juice-sdk-react` npm names aren't controlled by this repo's publish token, so the packages are republished under the `@bananapus` scope:

- `juice-sdk-core@3.0.0` → **`@bananapus/nana-sdk-core@1.0.0`**
- `juice-sdk-react@6.0.2` → **`@bananapus/nana-sdk-react@1.0.0`**

Changes: package names + versions, the react package's imports/peer-dep on the core package, and README install/import examples. `publishConfig.access: public` was already set (required for scoped packages). No changeset needed — `changeset publish` publishes any workspace package whose name@version isn't on the registry, so merging this triggers the 1.0.0 publish of both packages on the next Release run (with the updated NPM_TOKEN).

`npm run build` and `npm test` (48 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)