### PR TITLE
Fix v6 action-layer review findings

### DIFF
--- a/.changeset/v6-actions-fixes.md
+++ b/.changeset/v6-actions-fixes.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-core": patch
+---
+
+Review fixes for the v6 action layer: `buildDeployRevnetTx` no longer attaches the creation fee when initializing an EXISTING project as a revnet (the deployer reverts on any value in that case; `creationFee` is now optional and only required for new revnets). `fillSplitPercents` throws when input drift exceeds rounding error instead of silently rewriting un-normalized groups. The package's `require` conditions now serve real CommonJS output (previously ESM was emitted into `dist/cjs`, breaking `require()` consumers). Docs: USDC-accounting caveat on `getCashOutQuote`, README example fix.

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ const request = buildPayTx({
   amount: 10n ** 18n,
   beneficiary: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
 });
-await wallet.writeContract({ account, ...request });
+await wallet.writeContract({ account: "0xYourAccount", ...request });
 ```
 
 Modules:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
     "prebuild": "rm -Rf dist/",
     "build": "npm run generate && npm run build:esm && npm run build:cjs",
     "build:esm": "tsc --project ./tsconfig.json",
-    "build:cjs": "tsc --project ./tsconfig.cjs.json",
+    "build:cjs": "tsc --project ./tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
     "dev": "tsc --project ./tsconfig.json --watch --preserveWatchOutput",
     "test": "vitest run",
     "type-check": "tsc --noEmit"

--- a/packages/core/src/v6/cashOut.ts
+++ b/packages/core/src/v6/cashOut.ts
@@ -108,6 +108,11 @@ export interface CashOutQuote {
  * accounting-context currency, `uint32(uint160(token))`). Defaults to the native
  * token's currency (61166).
  * @returns The raw reclaim amount and the amount net of the 2.5% protocol fee.
+ *
+ * NOTE: the defaults quote in NATIVE terms (decimals 18, token-keyed native
+ * currency). For a project whose accounting token is not the native token
+ * (e.g. USDC), pass that token's `decimals` and `tokenCurrencyId(token)` to
+ * quote in its own terms and avoid a price-feed conversion.
  */
 export async function getCashOutQuote(
   client: PublicClient,

--- a/packages/core/src/v6/revnets.ts
+++ b/packages/core/src/v6/revnets.ts
@@ -109,8 +109,10 @@ export function buildRevnetStageConfig(args: {
  * Build a `REVDeployer.deployFor` transaction request deploying a new revnet
  * (or a 721-shop revnet when `tiered721Config` is given).
  *
- * The transaction is payable and must send EXACTLY the current project
- * creation fee — read it with `getProjectCreationFee` on the same chain.
+ * Deploying a NEW revnet (`revnetId` 0n) is payable and must send EXACTLY the
+ * current project creation fee — read it with `getProjectCreationFee` on the
+ * same chain. Deploying for an EXISTING project must send no value (the
+ * deployer reverts otherwise), so `creationFee` is ignored in that case.
  * For omnichain revnets, send one transaction per chain with an identical
  * `config` (shared description salt, shared absolute stage starts) and a
  * shared sucker salt.
@@ -133,13 +135,20 @@ export function buildDeployRevnetTx(args: {
   config: REVConfig;
   accountingContexts: readonly JBAccountingContext[];
   suckerConfig: REVSuckerDeploymentConfig;
-  creationFee: bigint;
+  creationFee?: bigint;
   revnetId?: bigint;
   tiered721Config?: REVDeploy721TiersHookConfig;
   allowedPosts?: readonly REVCroptopAllowedPost[];
 }) {
   const address = v6Address("REVDeployer", args.chainId);
   const revnetId = args.revnetId ?? 0n;
+
+  // The deployer forwards msg.value to `JBProjects.createFor` for new revnets and
+  // reverts on any value when initializing an existing project.
+  if (revnetId === 0n && args.creationFee === undefined) {
+    throw new Error("creationFee is required when deploying a new revnet");
+  }
+  const value = revnetId === 0n ? (args.creationFee as bigint) : 0n;
 
   if (args.tiered721Config) {
     return {
@@ -155,7 +164,7 @@ export function buildDeployRevnetTx(args: {
         args.tiered721Config,
         args.allowedPosts ?? [],
       ] as const,
-      value: args.creationFee,
+      value,
     };
   }
   return {
@@ -169,7 +178,7 @@ export function buildDeployRevnetTx(args: {
       args.accountingContexts,
       args.suckerConfig,
     ] as const,
-    value: args.creationFee,
+    value,
   };
 }
 

--- a/packages/core/src/v6/splits.test.ts
+++ b/packages/core/src/v6/splits.test.ts
@@ -57,14 +57,20 @@ describe("fillSplitPercents", () => {
     expect(filled.slice(1)).toEqual(Array(6).fill(seventh));
   });
 
-  test("a lone zero share absorbs the whole total", () => {
-    expect(fillSplitPercents([0])).toEqual([SPLITS_TOTAL_PERCENT]);
+  test("throws when the drift exceeds rounding error", () => {
+    expect(() => fillSplitPercents([0])).toThrow(/drift larger than rounding/);
+    expect(() => fillSplitPercents([50, 50])).toThrow(
+      /drift larger than rounding/,
+    );
+    expect(() => fillSplitPercents([0, 0, 0])).toThrow(
+      /drift larger than rounding/,
+    );
   });
 
   test("does not mutate the input", () => {
-    const shares = [1, 2, 3];
+    const shares = [499999999, 499999999, 1];
     fillSplitPercents(shares);
-    expect(shares).toEqual([1, 2, 3]);
+    expect(shares).toEqual([499999999, 499999999, 1]);
   });
 
   test("throws on negative or non-integer shares", () => {
@@ -84,10 +90,10 @@ describe("fillSplitPercents", () => {
   });
 
   test("throws when the group oversums beyond repair", () => {
-    // sum = 1.8e9; the -8e8 delta exceeds any single share.
+    // sum = 1.8e9; the -8e8 delta far exceeds rounding error.
     expect(() =>
       fillSplitPercents([600_000_000, 600_000_000, 600_000_000]),
-    ).toThrow(/exceeds SPLITS_TOTAL_PERCENT/);
+    ).toThrow(/drift larger than rounding/);
   });
 });
 

--- a/packages/core/src/v6/splits.ts
+++ b/packages/core/src/v6/splits.ts
@@ -52,8 +52,9 @@ export function payoutSplitGroupId(token: Address): bigint {
  * corrected here).
  * @returns A new array summing to exactly `SPLITS_TOTAL_PERCENT`. An empty
  * input returns an empty array (an empty group is valid).
- * @throws If a share is negative or non-integer, or if the drift is larger
- * than the largest share (the input was not approximately normalized).
+ * @throws If a share is negative or non-integer, or if the drift from
+ * `SPLITS_TOTAL_PERCENT` exceeds one unit per share (the input was not
+ * normalized to `SPLITS_TOTAL_PERCENT`).
  */
 export function fillSplitPercents(shares: number[]): number[] {
   if (shares.length === 0) return [];
@@ -69,14 +70,18 @@ export function fillSplitPercents(shares: number[]): number[] {
   const delta = SPLITS_TOTAL_PERCENT - sum;
   if (delta === 0) return filled;
 
+  // Per-row rounding can drift by at most one unit per share. Anything larger means
+  // the input wasn't normalized to SPLITS_TOTAL_PERCENT — silently rewriting it would
+  // hand a beneficiary a very different share than intended.
+  if (Math.abs(delta) > filled.length) {
+    throw new Error(
+      `Split shares sum to ${sum}; expected ~${SPLITS_TOTAL_PERCENT} (drift larger than rounding error)`,
+    );
+  }
+
   let largestIndex = 0;
   for (let i = 1; i < filled.length; i++) {
     if (filled[i] > filled[largestIndex]) largestIndex = i;
-  }
-  if (filled[largestIndex] + delta < 0) {
-    throw new Error(
-      `Split shares sum to ${sum}, which exceeds SPLITS_TOTAL_PERCENT (${SPLITS_TOTAL_PERCENT}) by more than the largest share`,
-    );
   }
   filled[largestIndex] += delta;
   return filled;

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "outDir": "./dist/cjs"
   }
 }


### PR DESCRIPTION
## Summary

Post-merge adversarial review of #28 surfaced three real issues, fixed here (patch changeset → core 1.1.1):

1. **`buildDeployRevnetTx` reverted for existing revnets** — it attached the creation fee unconditionally, but `REVDeployer.deployFor` reverts with `REVDeployer_ProjectCreationFeeNotNeeded` on any `msg.value` when `revnetId != 0` (initializing a pre-created project — the recommended flow for cross-chain deploys). The fee is now only sent for new revnets; `creationFee` is optional and validated when `revnetId` is 0.
2. **`require()` consumers got ESM** — the package has `"type": "module"` and `tsconfig.cjs.json` used `module: Node16`, so `dist/cjs` contained ESM and every `require` condition (root and `/v6`) threw `ERR_REQUIRE_ESM` (pre-existing on the root export; extended to the new subpath by #28). `dist/cjs` now compiles as real CommonJS with a `{"type":"commonjs"}` marker.
3. **`fillSplitPercents` silently rewrote un-normalized input** — e.g. `[50, 50]` (percent-style) became `[999_999_950, 50]`, handing the first beneficiary ~100%. It now throws when the drift exceeds rounding error (one unit per share); exact-remainder fill behavior for genuinely rounded groups is unchanged.

Plus docs: USDC-accounting caveat on `getCashOutQuote` defaults, README example fix.

All findings other than these verified clean in the review (arg orders, bytes32 shapes, 721 metadata wire format, permission ids, overload selection — checked against canonical ABIs and contract sources). 99 v6 tests pass (updated for the new splits guard); build clean; the review's full notes are available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)