### PR TITLE
Add native-bridge sucker deployment option to the v6 SDK

### DIFF
--- a/.changeset/native-bridge-suckers.md
+++ b/.changeset/native-bridge-suckers.md
@@ -1,0 +1,7 @@
+---
+"@bananapus/nana-sdk-core": minor
+---
+
+v6 sucker deployment can now use native bridges alongside CCIP. `parseSuckerDeployerConfig` and `buildOmnichainLaunchProjectTx` take a `bridge` option: `"ccip"` (default, unchanged), `"native"` (OP/Base/Arbitrum standard-bridge suckers — Ethereum<->L2 pairs only), or `"both"` (one native AND one CCIP sucker per pair for redundancy; L2<->L2 pairs fall back to CCIP alone). Native-bridge deployer addresses ship as `NATIVE_SUCKER_DEPLOYER_ADDRESSES` / `jbNativeSuckerDeployerAddress`.
+
+Safety: native suckers only receive native-token mappings. Standard bridges deliver bridge-wrapped USDC.e — never canonical USDC — so a canonical-USDC mapping over a native bridge locks funds in bridge escrow (OP/Base) or strands them on the remote sucker (Arbitrum), and neither the sucker contracts nor the registry allowlist prevent it. `"native"` + USDC throws; `"both"` + USDC keeps the USDC mapping on the CCIP sucker only.

--- a/packages/core/scripts/addJBProjectDeploymentAddresses.ts
+++ b/packages/core/scripts/addJBProjectDeploymentAddresses.ts
@@ -4,6 +4,7 @@ import {
   getAllContractNames,
   getContractAddress,
   getV6CcipDeployerAddress,
+  getV6NativeDeployerAddress,
 } from "./utils.js";
 
 const chainIds = Object.keys(SUPPORTED_CHAINS).map(Number) as JBChainId[];
@@ -60,6 +61,30 @@ async function buildV6CcipDeployerAddresses() {
   return addresses;
 }
 
+/**
+ * v6 native-bridge sucker deployer addresses, keyed by local chain then remote chain.
+ * Only L1<->L2 edges exist (native bridges only connect Ethereum with an L2).
+ */
+async function buildV6NativeDeployerAddresses() {
+  const addresses = {};
+
+  for (const chainId of chainIds) {
+    const isMainnet = MAINNET_CHAIN_IDS.includes(chainId);
+    const peers = chainIds.filter(
+      (peer) =>
+        peer !== chainId && MAINNET_CHAIN_IDS.includes(peer) === isMainnet,
+    );
+
+    addresses[chainId] = {};
+    for (const peer of peers) {
+      const address = await getV6NativeDeployerAddress(chainId, peer);
+      if (address) addresses[chainId][peer] = address;
+    }
+  }
+
+  return addresses;
+}
+
 async function buildDefaultAddressContent() {
   const content = `
   /**
@@ -81,6 +106,18 @@ async function buildDefaultAddressContent() {
   export const jbCcipSuckerDeployerAddress = ${JSON.stringify(
     {
       6: await buildV6CcipDeployerAddresses(),
+    },
+    null,
+    2,
+  )} as const;
+
+  /**
+   * v6 native-bridge sucker deployer addresses, keyed by local chain then remote chain.
+   * Native bridges only connect Ethereum with an L2, so only L1<->L2 edges exist.
+   */
+  export const jbNativeSuckerDeployerAddress = ${JSON.stringify(
+    {
+      6: await buildV6NativeDeployerAddresses(),
     },
     null,
     2,

--- a/packages/core/scripts/utils.ts
+++ b/packages/core/scripts/utils.ts
@@ -124,6 +124,38 @@ const CCIP_REMOTE_LABELS: Record<JBChainId, string> = {
   421614: "ARB_SEP",
 };
 
+/**
+ * The address of the v6 native-bridge sucker deployer on `chainId` that bridges to
+ * `peerChainId`, or null when the pair has no native bridge (native bridges only connect
+ * Ethereum with an L2). The deployer is named after the pair's rollup on both sides
+ * (e.g. `JBOptimismSuckerDeployer` on both ethereum and optimism).
+ */
+export async function getV6NativeDeployerAddress(
+  chainId: JBChainId,
+  peerChainId: JBChainId,
+) {
+  const localIsL1 = L1_CHAIN_IDS.includes(chainId);
+  const peerIsL1 = L1_CHAIN_IDS.includes(peerChainId);
+  if (localIsL1 === peerIsL1) return null;
+  const rollup = NATIVE_ROLLUP_LABELS[localIsL1 ? peerChainId : chainId];
+  if (!rollup) return null;
+  const { address } = await importDeploymentFile(
+    `@bananapus/suckers-v6/deployments/${getChainName(chainId)}/JB${rollup}SuckerDeployer.json`,
+  );
+  return address;
+}
+
+const L1_CHAIN_IDS: JBChainId[] = [1, 11155111];
+
+const NATIVE_ROLLUP_LABELS: Partial<Record<JBChainId, string>> = {
+  10: "Optimism",
+  8453: "Base",
+  42161: "Arbitrum",
+  11155420: "Optimism",
+  84532: "Base",
+  421614: "Arbitrum",
+};
+
 async function getContract(
   contract: Contract,
   version: JBVersion,

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -12,6 +12,7 @@ import {
 import {
   jbCcipSuckerDeployerAddress,
   jbContractAddress,
+  jbNativeSuckerDeployerAddress,
 } from "./generated/juicebox.js";
 import { JBChainId, JBSuckerContracts, JBVersion } from "./types.js";
 
@@ -207,7 +208,7 @@ export const JB_CHAIN_SLUGS = Object.values(JB_CHAINS).reduce(
 
 export const DEFAULT_NATIVE_TOKEN_SYMBOL = "ETH";
 
-type CCIPMap = {
+type SuckerDeployerMap = {
   [k in JBChainId]?: {
     [k in JBChainId]?: Address;
   };
@@ -220,8 +221,8 @@ type CCIPMap = {
  *
  * @see https://discord.com/channels/1139291093310132376/1139291094069301385/1337164727008366683
  */
-export const CCIP_SUCKER_DEPLOYER_ADDRESSES: Record<5 | 6, CCIPMap> = {
-  6: jbCcipSuckerDeployerAddress[6] as CCIPMap,
+export const CCIP_SUCKER_DEPLOYER_ADDRESSES: Record<5 | 6, SuckerDeployerMap> = {
+  6: jbCcipSuckerDeployerAddress[6] as SuckerDeployerMap,
   5: {
     [sepolia.id]: {
       [optimismSepolia.id]:
@@ -333,6 +334,15 @@ export const CCIP_SUCKER_DEPLOYER_ADDRESSES: Record<5 | 6, CCIPMap> = {
         jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][base.id],
     },
   },
+};
+
+/**
+ * Native-bridge (OP/Base/Arbitrum standard bridge) sucker deployer addresses, keyed by
+ * version, then local chain, then remote chain. Native bridges only connect Ethereum
+ * with an L2, so only L1<->L2 edges exist. v6 only.
+ */
+export const NATIVE_SUCKER_DEPLOYER_ADDRESSES: Record<6, SuckerDeployerMap> = {
+  6: jbNativeSuckerDeployerAddress[6] as SuckerDeployerMap,
 };
 
 /**

--- a/packages/core/src/generated/juicebox.ts
+++ b/packages/core/src/generated/juicebox.ts
@@ -62528,3 +62528,40 @@ export const revOwnerAbi = [
     }
   }
 } as const;
+
+  /**
+   * v6 native-bridge sucker deployer addresses, keyed by local chain then remote chain.
+   * Native bridges only connect Ethereum with an L2, so only L1<->L2 edges exist.
+   */
+  export const jbNativeSuckerDeployerAddress = {
+  "6": {
+    "1": {
+      "10": "0x298a775c030adcedb641a89d9047ec9972674e1a",
+      "8453": "0x54140331902de5c3445eb0c26e15099a5a9d59e6",
+      "42161": "0xa12ebfca3d4e0810e4ed174e4c08277c26917acb"
+    },
+    "10": {
+      "1": "0x298a775c030adcedb641a89d9047ec9972674e1a"
+    },
+    "8453": {
+      "1": "0x54140331902de5c3445eb0c26e15099a5a9d59e6"
+    },
+    "42161": {
+      "1": "0xa12ebfca3d4e0810e4ed174e4c08277c26917acb"
+    },
+    "84532": {
+      "11155111": "0x54140331902de5c3445eb0c26e15099a5a9d59e6"
+    },
+    "421614": {
+      "11155111": "0xa12ebfca3d4e0810e4ed174e4c08277c26917acb"
+    },
+    "11155111": {
+      "84532": "0x54140331902de5c3445eb0c26e15099a5a9d59e6",
+      "421614": "0xa12ebfca3d4e0810e4ed174e4c08277c26917acb",
+      "11155420": "0x298a775c030adcedb641a89d9047ec9972674e1a"
+    },
+    "11155420": {
+      "11155111": "0x298a775c030adcedb641a89d9047ec9972674e1a"
+    }
+  }
+} as const;

--- a/packages/core/src/utils/deploy.test.ts
+++ b/packages/core/src/utils/deploy.test.ts
@@ -33,3 +33,83 @@ describe("sucker parsing", () => {
     expect(result.salt).toBe(salt);
   });
 });
+
+describe("v6 bridge selection", () => {
+  test("native bridges from mainnet to each L2", () => {
+    const result = parseSuckerDeployerConfig(
+      mainnet.id,
+      [optimism.id, arbitrum.id, base.id],
+      [MappableAsset.NATIVE],
+      { version: 6, bridge: "native" },
+    );
+
+    expect(result.deployerConfigurations.length).toBe(3);
+    expect(result.deployerConfigurations[0].deployer).toBe(
+      "0x298a775c030adcedb641a89d9047ec9972674e1a", // JBOptimismSuckerDeployer
+    );
+  });
+
+  test("both deploys a native and a CCIP sucker per L1<->L2 pair", () => {
+    const result = parseSuckerDeployerConfig(
+      mainnet.id,
+      [optimism.id],
+      [MappableAsset.NATIVE],
+      { version: 6, bridge: "both" },
+    );
+
+    expect(result.deployerConfigurations.length).toBe(2);
+    const [native, ccip] = result.deployerConfigurations;
+    expect(native.deployer).not.toBe(ccip.deployer);
+  });
+
+  test("both falls back to CCIP alone for L2<->L2 pairs", () => {
+    const result = parseSuckerDeployerConfig(
+      optimism.id,
+      [base.id],
+      [MappableAsset.NATIVE],
+      { version: 6, bridge: "both" },
+    );
+
+    expect(result.deployerConfigurations.length).toBe(1);
+  });
+
+  test("native throws for L2<->L2 pairs", () => {
+    expect(() =>
+      parseSuckerDeployerConfig(optimism.id, [base.id], [MappableAsset.NATIVE], {
+        version: 6,
+        bridge: "native",
+      }),
+    ).toThrow(/native bridges only connect Ethereum with an L2/);
+  });
+
+  test("native throws for USDC (bridge-wrapped USDC.e trap)", () => {
+    expect(() =>
+      parseSuckerDeployerConfig(mainnet.id, [optimism.id], [MappableAsset.USDC], {
+        version: 6,
+        bridge: "native",
+      }),
+    ).toThrow(/USDC\.e/);
+  });
+
+  test("both keeps USDC on the CCIP sucker only", () => {
+    const result = parseSuckerDeployerConfig(
+      mainnet.id,
+      [optimism.id],
+      [MappableAsset.NATIVE, MappableAsset.USDC],
+      { version: 6, bridge: "both" },
+    );
+
+    expect(result.deployerConfigurations.length).toBe(2);
+    const [native, ccip] = result.deployerConfigurations;
+    expect(native.mappings.length).toBe(1); // native token only
+    expect(ccip.mappings.length).toBe(2); // native + USDC
+  });
+
+  test("native is rejected for pre-v6 deployments", () => {
+    expect(() =>
+      parseSuckerDeployerConfig(mainnet.id, [optimism.id], [MappableAsset.NATIVE], {
+        bridge: "native",
+      }),
+    ).toThrow(/only supported for v6/);
+  });
+});

--- a/packages/core/src/utils/deploy.ts
+++ b/packages/core/src/utils/deploy.ts
@@ -1,6 +1,7 @@
 import { pad, zeroHash } from "viem";
 import {
   CCIP_SUCKER_DEPLOYER_ADDRESSES,
+  NATIVE_SUCKER_DEPLOYER_ADDRESSES,
   NATIVE_TOKEN,
   USDC_ADDRESSES,
 } from "../constants.js";
@@ -8,7 +9,7 @@ import { JBChainId, JBVersion } from "../types.js";
 import { createSalt } from "./tx.js";
 
 // NOTE: A default of `0` is safe as long as we are deploying CCIP suckers, this is not a safe default for non-ccip suckers.
-// Currently the SDK is only able to deploy CCIP suckers so this is a safe default, but in case that changes this should be refactored.
+// v4/v5 deployments (which take a min bridge amount) are CCIP-only, so this is a safe default.
 const DEFAULT_MIN_BRIDGE_AMOUNT = BigInt(0);
 
 // Assets that the SDK has built-in support for mapping.
@@ -16,6 +17,19 @@ export enum MappableAsset {
   NATIVE,
   USDC,
 }
+
+/**
+ * The bridge infrastructure to deploy v6 suckers on:
+ *
+ * - `"ccip"`: Chainlink CCIP suckers. Connect any pair of supported chains and can map
+ *   any supported asset (USDC bridges as canonical USDC via CCTP).
+ * - `"native"`: OP/Base/Arbitrum standard-bridge suckers. Strongest trust guarantees, but
+ *   only connect Ethereum with an L2 (never L2<->L2), only map the native token, and
+ *   L2->L1 exits wait out the bridge's ~7-day challenge period.
+ * - `"both"`: one native sucker AND one CCIP sucker per pair, for redundancy. Pairs or
+ *   assets native bridges can't serve are covered by the CCIP sucker alone.
+ */
+export type JBSuckerBridge = "ccip" | "native" | "both";
 
 export function parseSuckerDeployerConfig(
   targetChainId: JBChainId,
@@ -27,14 +41,24 @@ export function parseSuckerDeployerConfig(
      * The JB protocol version being deployed. Defaults to 5, which is also used for v4 deployments.
      */
     version?: JBVersion;
+    /**
+     * The bridge infrastructure to deploy suckers on. Defaults to "ccip".
+     * "native" and "both" are v6-only.
+     */
+    bridge?: JBSuckerBridge;
   } = {},
 ) {
-  const deployerAddresses =
+  const bridge = opts.bridge ?? "ccip";
+  if (bridge !== "ccip" && opts.version !== 6) {
+    throw new Error(`Native-bridge suckers are only supported for v6 deployments`);
+  }
+
+  const ccipDeployers =
     CCIP_SUCKER_DEPLOYER_ADDRESSES[opts.version === 6 ? 6 : 5];
   const suckerChains = chains.filter((chainId) => chainId !== targetChainId);
 
-  const getDeployer = (chainId: JBChainId) => {
-    const deployer = deployerAddresses[targetChainId]?.[chainId];
+  const getCcipDeployer = (chainId: JBChainId) => {
+    const deployer = ccipDeployers[targetChainId]?.[chainId];
     if (!deployer) {
       throw new Error(`No deployer found for ${targetChainId} -> ${chainId}`);
     }
@@ -53,24 +77,59 @@ export function parseSuckerDeployerConfig(
     }
   };
 
+  // v6 mappings identify remote tokens as bytes32 and no longer take a min bridge amount.
+  const toV6Mapping = (asset: MappableAsset, chainId: JBChainId) => {
+    const { localToken, remoteToken } = getTokens(asset, chainId);
+    return {
+      localToken,
+      minGas: 200_000,
+      remoteToken: pad(remoteToken),
+    };
+  };
+
+  // The native-bridge sucker config for one (local -> remote) pair, or undefined when
+  // the pair/assets can't go native but the CCIP sucker covers them (bridge "both").
+  const v6NativeConfigFor = (chainId: JBChainId) => {
+    const deployer = NATIVE_SUCKER_DEPLOYER_ADDRESSES[6][targetChainId]?.[chainId];
+    // Standard bridges deliver bridge-wrapped tokens (USDC.e, never canonical USDC),
+    // which would strand funds on the remote sucker — only map the native token.
+    const nativeAssets = assets.filter(
+      (asset) => asset === MappableAsset.NATIVE,
+    );
+    if (deployer && nativeAssets.length > 0) {
+      return {
+        deployer,
+        peer: zeroHash,
+        mappings: nativeAssets.map((asset) => toV6Mapping(asset, chainId)),
+      };
+    }
+    if (bridge === "both") return undefined;
+    throw new Error(
+      deployer
+        ? `Only the native token can bridge over native bridges (they deliver bridge-wrapped tokens like USDC.e); use bridge "ccip" or "both" to map other assets`
+        : `No native bridge between ${targetChainId} and ${chainId} (native bridges only connect Ethereum with an L2); use bridge "ccip" or "both"`,
+    );
+  };
+
   // v6 configs identify remote tokens/peers as bytes32 (a zero peer means the default
-  // same-address deterministic peer), and no longer take a min bridge amount.
+  // same-address deterministic peer). One config per (remote chain, bridge kind) pair.
   const deployerConfigurations =
     opts.version === 6
-      ? suckerChains.map((chainId) => ({
-          deployer: getDeployer(chainId),
-          peer: zeroHash,
-          mappings: assets.map((asset) => {
-            const { localToken, remoteToken } = getTokens(asset, chainId);
-            return {
-              localToken,
-              minGas: 200_000,
-              remoteToken: pad(remoteToken),
-            };
-          }),
-        }))
+      ? suckerChains.flatMap((chainId) => {
+          const native =
+            bridge === "ccip" ? undefined : v6NativeConfigFor(chainId);
+          const ccip =
+            bridge === "native"
+              ? undefined
+              : {
+                  deployer: getCcipDeployer(chainId),
+                  peer: zeroHash,
+                  mappings: assets.map((asset) => toV6Mapping(asset, chainId)),
+                };
+          return [...(native ? [native] : []), ...(ccip ? [ccip] : [])];
+        })
       : suckerChains.map((chainId) => ({
-          deployer: getDeployer(chainId),
+          deployer: getCcipDeployer(chainId),
           mappings: assets.map((asset) => ({
             ...getTokens(asset, chainId),
             minGas: 200_000,

--- a/packages/core/src/v6/omnichain.ts
+++ b/packages/core/src/v6/omnichain.ts
@@ -1,7 +1,11 @@
 import { Address, ContractFunctionArgs, Hex } from "viem";
 import { jbOmnichainDeployerAbi } from "../generated/juicebox.js";
 import { JBChainId } from "../types.js";
-import { MappableAsset, parseSuckerDeployerConfig } from "../utils/deploy.js";
+import {
+  JBSuckerBridge,
+  MappableAsset,
+  parseSuckerDeployerConfig,
+} from "../utils/deploy.js";
 import { JBTerminalConfig } from "./launch.js";
 import { JBRulesetConfig } from "./rulesets.js";
 import { v6Address } from "./types.js";
@@ -59,6 +63,10 @@ export type JBSuckerDeploymentConfig = OmnichainLaunchArgs6[5];
  * `chainId`); sucker deployer configs are built for every other chain.
  * @param args.assets The assets to bridge between chains. Defaults to the
  * native token only.
+ * @param args.bridge The bridge infrastructure the suckers use: "ccip" (any
+ * chain pair, any asset — the default), "native" (OP/Base/Arbitrum standard
+ * bridges: Ethereum<->L2 pairs and the native token only), or "both" (a
+ * native AND a CCIP sucker per pair where both exist, for redundancy).
  * @param args.salt The shared salt (use the same value on every chain).
  * @param args.deploy721Config Optional tiered 721 hook to deploy with the
  * project (uses the 7-arg overload when given).
@@ -76,6 +84,7 @@ export function buildOmnichainLaunchProjectTx(args: {
   creationFee: bigint;
   salt: Hex;
   assets?: MappableAsset[];
+  bridge?: JBSuckerBridge;
   deploy721Config?: JBDeploy721TiersHookConfig;
 }) {
   // parseSuckerDeployerConfig's return type is a v5/v6 union that TS cannot
@@ -85,7 +94,7 @@ export function buildOmnichainLaunchProjectTx(args: {
     args.chainId,
     args.chainIds,
     args.assets ?? [MappableAsset.NATIVE],
-    { salt: args.salt, version: 6 },
+    { salt: args.salt, version: 6, bridge: args.bridge },
   ) as unknown as JBSuckerDeploymentConfig;
 
   const address = v6Address("JBOmnichainDeployer", args.chainId);


### PR DESCRIPTION
## What

v6 sucker deployment can now choose bridge infrastructure, mirroring the jb-directory website's selector. `parseSuckerDeployerConfig(..., { version: 6, bridge })` and `buildOmnichainLaunchProjectTx({ bridge })` accept:

- **`"ccip"`** (default) — unchanged behavior; existing callers are unaffected.
- **`"native"`** — OP/Base/Arbitrum standard-bridge suckers. Ethereum↔L2 pairs only; an L2↔L2 pair throws.
- **`"both"`** — one native AND one CCIP sucker per pair, matching the redundancy topology deploy-all uses for the canonical revnets. L2↔L2 pairs (no native bridge exists) fall back to CCIP alone.

Native deployer addresses are generated from the `@bananapus/suckers-v6` deployment artifacts into `jbNativeSuckerDeployerAddress` (codegen: `getV6NativeDeployerAddress`) and exposed as `NATIVE_SUCKER_DEPLOYER_ADDRESSES`.

## USDC guard

Native suckers only receive native-token mappings. `JBOptimismSucker` passes the mapping's `remoteToken` straight into `StandardBridge.bridgeERC20To`, and canonical L2 USDC is not an `OptimismMintableERC20` pair of L1 USDC — the destination `finalizeBridgeERC20` can never succeed, locking funds in bridge escrow after the outbox tree has advanced. On Arbitrum, L1→L2 delivers bridge-wrapped USDC.e to the peer sucker (claims revert `JBSucker_InsufficientBalance`) and L2→L1 reverts at `toRemote`. Neither the sucker contracts' `_validateTokenMapping` nor the registry's token-mapping allowlist (which is keyed by token tuple only, not bridge infra, and globally allowlists canonical-USDC pairs) reject the mapping — so the SDK refuses to build it:

- `bridge: "native"` + `MappableAsset.USDC` throws.
- `bridge: "both"` + USDC puts the USDC mapping on the CCIP sucker only (CCIP routes USDC through the CCTP-backed pool → canonical USDC).

## Testing

- 7 new tests in `deploy.test.ts` covering native, both, L2↔L2 fallback and throw, both USDC guards, and pre-v6 rejection; 153/153 core tests pass.
- `npm run generate` round-trips: the committed `jbNativeSuckerDeployerAddress` block is byte-identical to fresh codegen output.
- ESM + CJS builds and the react package build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)