### PR TITLE
Add v6 JB721 shop helpers; fix build721PayMetadata silent-mint footgun

### DIFF
--- a/.changeset/721-shop-helpers.md
+++ b/.changeset/721-shop-helpers.md
@@ -1,0 +1,9 @@
+---
+"@bananapus/nana-sdk-core": minor
+---
+
+Add v6 JB721 "shop" helpers and fix a silent-mint footgun in `build721PayMetadata`.
+
+- `getProject721Shop(client, { chainId, projectId, isRevnet })` resolves a project's 721 tiers hook, its store, the metadata id target, the pricing context, and its tiers in one call (revnet and custom/omnichain hook resolution; returns `null` for projects with no shop, throws on RPC failure). Plus `get721MetadataIdTarget`, `effectiveTierPrice`, and `DISCOUNT_DENOMINATOR`.
+- `build721CashOutMetadata({ metadataIdTarget, tokenIds })` builds the cash-out (NFT redeem) metadata — the mirror of `build721PayMetadata` — reusing the shared metadata packer.
+- `build721PayMetadata` now takes `metadataIdTarget` (the hook's `METADATA_ID_TARGET` — the shared *implementation* address). `hookAddress` is kept as a deprecated alias. Passing a project's clone hook address as the target produces an id the hook never matches, so the payment silently mints ZERO NFTs; the new param name plus `get721MetadataIdTarget` make the correct target explicit. The metadata id formula is unchanged, so existing correct callers are unaffected.

--- a/.changeset/721-shop-react-hooks.md
+++ b/.changeset/721-shop-react-hooks.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-react": minor
+---
+
+Add `useShopPurchases` and `useOwnedShopItems` hooks for a project's 721 "shop": the customers/purchases feed (bendystraw `mintNftEvents`) and a holder's currently-owned store items (bendystraw `nfts`), for the project + chain in context. `useOwnedShopItems` is the basis for a redeem/cash-out list (verify `ownerOf` on-chain before offering a redemption). The typed query documents are hand-written (self-contained) rather than codegen'd, so they add no generated-schema churn.

--- a/packages/core/src/utils/hook.ts
+++ b/packages/core/src/utils/hook.ts
@@ -1,9 +1,38 @@
-import { Hash, encodePacked, zeroHash } from "viem";
+import {
+  Address,
+  Hash,
+  Hex,
+  bytesToHex,
+  encodePacked,
+  keccak256,
+  toBytes,
+  zeroHash,
+} from "viem";
+
+/**
+ * The metadata lookup id a JB hook resolves via `JBMetadataResolver.getId`:
+ * `bytes4(bytes20(target) ^ bytes20(keccak256(purpose)))`.
+ *
+ * For JB721 hooks, `target` MUST be the hook's `METADATA_ID_TARGET` — which is
+ * `address(this)` in the *implementation's* constructor, so every delegatecall
+ * clone reports the shared implementation address, NOT its own clone address.
+ * Passing the clone address yields an id the hook never matches, so the pay or
+ * cash out silently ignores the tier/token payload. Resolve the target with
+ * `get721MetadataIdTarget` rather than passing a hook address directly.
+ *
+ * @link https://github.com/Bananapus/nana-core-v6/blob/main/src/libraries/JBMetadataResolver.sol (`getId`)
+ */
+export function hookMetadataId(target: Address, purpose: string): Hex {
+  const targetBytes = toBytes(target).slice(0, 20);
+  const purposeBytes = toBytes(keccak256(toBytes(purpose))).slice(0, 20);
+  const xored = targetBytes.map((byte, i) => byte ^ purposeBytes[i]);
+  return bytesToHex(xored.slice(0, 4));
+}
 
 /**
  *
  * Create metadata for pay or redeem hooks.
- * 
+ *
  * @link https://github.com/simplemachine92/JBMetadata-Helper
  * @attribution simplemachine92/nowonder
  */

--- a/packages/core/src/v6/cashOut.test.ts
+++ b/packages/core/src/v6/cashOut.test.ts
@@ -1,8 +1,17 @@
-import { PublicClient, encodeFunctionData } from "viem";
+import {
+  PublicClient,
+  decodeAbiParameters,
+  encodeFunctionData,
+  sliceHex,
+} from "viem";
 import { describe, expect, test } from "vitest";
 import { NATIVE_TOKEN, ONE_ETHER } from "../constants.js";
 import { jbTerminalStoreAbi } from "../generated/juicebox.js";
-import { buildCashOutTx, getCashOutQuote } from "./cashOut.js";
+import {
+  build721CashOutMetadata,
+  buildCashOutTx,
+  getCashOutQuote,
+} from "./cashOut.js";
 import { v6Address } from "./types.js";
 
 const chainId = 11155111;
@@ -107,5 +116,37 @@ describe("cashOut", () => {
       6n,
       0x3606eb48n,
     ]);
+  });
+
+  test("build721CashOutMetadata packs the cashOut id and token ids", () => {
+    // With a target whose first 4 bytes are zero, the id is the first 4 bytes
+    // of keccak256("cashOut").
+    const metadata = build721CashOutMetadata({
+      metadataIdTarget: "0x00000000000000000000000000000000DeaDBeef",
+      tokenIds: [1_000_000_001n, 1_000_000_002n],
+    });
+
+    expect(sliceHex(metadata, 0, 32)).toEqual(`0x${"00".repeat(32)}`);
+    // keccak256("cashOut") first 4 bytes, then the payload word offset (2).
+    expect(sliceHex(metadata, 32, 36)).toEqual("0x86b14ff4");
+    expect(sliceHex(metadata, 36, 37)).toEqual("0x02");
+    const [tokenIds] = decodeAbiParameters(
+      [{ type: "uint256[]" }],
+      sliceHex(metadata, 64),
+    );
+    expect(tokenIds).toEqual([1_000_000_001n, 1_000_000_002n]);
+  });
+
+  test("build721CashOutMetadata rejects empty, duplicate, and zero token ids", () => {
+    const target = "0x00000000000000000000000000000000DeaDBeef" as const;
+    expect(() =>
+      build721CashOutMetadata({ metadataIdTarget: target, tokenIds: [] }),
+    ).toThrow(/at least one/);
+    expect(() =>
+      build721CashOutMetadata({ metadataIdTarget: target, tokenIds: [1n, 1n] }),
+    ).toThrow(/unique/);
+    expect(() =>
+      build721CashOutMetadata({ metadataIdTarget: target, tokenIds: [0n] }),
+    ).toThrow(/positive/);
   });
 });

--- a/packages/core/src/v6/cashOut.ts
+++ b/packages/core/src/v6/cashOut.ts
@@ -1,10 +1,11 @@
-import { Address, Hex, PublicClient } from "viem";
+import { Address, Hex, PublicClient, encodeAbiParameters } from "viem";
 import {
   jbMultiTerminalAbi,
   jbTerminalStoreAbi,
 } from "../generated/juicebox.js";
 import { JBChainId } from "../types.js";
 import { applyJbDaoCashOutFee } from "../utils/fee.js";
+import { createHookMetadata, hookMetadataId } from "../utils/hook.js";
 import { NATIVE_TOKEN_CURRENCY_ID } from "./currency.js";
 import { v6Address } from "./types.js";
 
@@ -73,6 +74,50 @@ export function buildCashOutTx({
       metadata,
     ],
   };
+}
+
+/**
+ * Build cash-out metadata instructing a project's JB721 tiers hook to burn
+ * specific NFTs and reclaim their share of surplus.
+ *
+ * The payload is `abi.encode(uint256[] tokenIds)`, keyed by the hook's cash-out
+ * metadata id (`bytes4(bytes20(metadataIdTarget) ^ bytes20(keccak256("cashOut")))`)
+ * and packed into the JBMetadataResolver word-offset-table format. This is the
+ * cash-out mirror of {@link build721PayMetadata}. The NFTs are burned by the hook
+ * itself, so no ERC-721 approval is needed; pass `cashOutCount: 0` to
+ * `cashOutTokensOf` (fungible tokens cannot co-redeem in the same call).
+ *
+ * @param args.metadataIdTarget The hook's `METADATA_ID_TARGET` — the shared
+ * *implementation* address, NOT the project's clone hook address (see
+ * {@link get721MetadataIdTarget}). Passing the clone address makes the hook ignore
+ * the token ids and no NFTs are burned.
+ * @param args.tokenIds The token ids of the NFTs to redeem. Must be non-empty,
+ * unique, and non-zero (a real NFT token id is never 0).
+ * @returns The metadata to pass as `cashOutTokensOf`'s `metadata` argument.
+ */
+export function build721CashOutMetadata({
+  metadataIdTarget,
+  tokenIds,
+}: {
+  metadataIdTarget: Address;
+  tokenIds: bigint[];
+}): Hex {
+  if (tokenIds.length === 0) {
+    throw new Error("build721CashOutMetadata requires at least one token id");
+  }
+  if (new Set(tokenIds.map(String)).size !== tokenIds.length) {
+    throw new Error("build721CashOutMetadata token ids must be unique");
+  }
+  if (tokenIds.some((tokenId) => tokenId <= 0n)) {
+    throw new Error("build721CashOutMetadata token ids must be positive");
+  }
+
+  const payload = encodeAbiParameters([{ type: "uint256[]" }], [tokenIds]);
+
+  return createHookMetadata(
+    [hookMetadataId(metadataIdTarget, "cashOut")],
+    [payload],
+  ) as Hex;
 }
 
 /**

--- a/packages/core/src/v6/index.ts
+++ b/packages/core/src/v6/index.ts
@@ -9,6 +9,7 @@ export * from "./revnets.js";
 export * from "./terminals.js";
 export * from "./pay.js";
 export * from "./cashOut.js";
+export * from "./nft.js";
 export * from "./tokens.js";
 export * from "./permissions.js";
 export * from "./suckers.js";

--- a/packages/core/src/v6/nft.test.ts
+++ b/packages/core/src/v6/nft.test.ts
@@ -1,0 +1,136 @@
+import { PublicClient, zeroAddress } from "viem";
+import { describe, expect, test } from "vitest";
+import {
+  DISCOUNT_DENOMINATOR,
+  effectiveTierPrice,
+  get721MetadataIdTarget,
+  getProject721Shop,
+} from "./nft.js";
+
+const chainId = 11155111;
+const hook = "0x1111111111111111111111111111111111111111" as const;
+const impl = "0x2222222222222222222222222222222222222222" as const;
+const store = "0x3333333333333333333333333333333333333333" as const;
+
+describe("effectiveTierPrice", () => {
+  test("floors like on-chain mulDiv(price, discountPercent, 200)", () => {
+    // 100 - floor(100 * 25 / 200) = 100 - 12 = 88.
+    expect(effectiveTierPrice(100n, 25)).toEqual(88n);
+  });
+
+  test("no discount returns the full price", () => {
+    expect(effectiveTierPrice(1000n, 0)).toEqual(1000n);
+  });
+
+  test("full discount (denominator) is free", () => {
+    expect(effectiveTierPrice(1000n, Number(DISCOUNT_DENOMINATOR))).toEqual(0n);
+  });
+
+  test("clamps discounts above the denominator to free", () => {
+    expect(effectiveTierPrice(1000n, 500)).toEqual(0n);
+  });
+});
+
+describe("get721MetadataIdTarget", () => {
+  test("returns METADATA_ID_TARGET (the implementation, not the clone)", async () => {
+    const client = {
+      readContract: async () => impl,
+    } as unknown as PublicClient;
+
+    expect(await get721MetadataIdTarget(client, { chainId, hook })).toEqual(impl);
+  });
+
+  test("falls back to the hook address if the getter reverts", async () => {
+    const client = {
+      readContract: async () => {
+        throw new Error("no such function");
+      },
+    } as unknown as PublicClient;
+
+    expect(await get721MetadataIdTarget(client, { chainId, hook })).toEqual(hook);
+  });
+});
+
+describe("getProject721Shop", () => {
+  test("returns null when a revnet has no 721 hook", async () => {
+    const client = {
+      // getRevnetTiered721Hook -> zero address.
+      readContract: async () => zeroAddress,
+    } as unknown as PublicClient;
+
+    expect(
+      await getProject721Shop(client, {
+        chainId,
+        projectId: 1n,
+        isRevnet: true,
+      }),
+    ).toBeNull();
+  });
+
+  test("resolves a revnet shop: hook, store, target, pricing, tiers", async () => {
+    const client = {
+      readContract: async ({
+        address,
+        functionName,
+      }: {
+        address: string;
+        functionName: string;
+      }) => {
+        if (functionName === "tiered721HookOf") return hook; // REVOwner
+        if (address === hook && functionName === "STORE") return store;
+        if (functionName === "METADATA_ID_TARGET") return impl;
+        if (functionName === "pricingContext") return [61166n, 18n];
+        if (functionName === "tiersOf") {
+          return [
+            {
+              id: 1,
+              price: 1000n,
+              remainingSupply: 5,
+              initialSupply: 10,
+              votingUnits: 0n,
+              reserveFrequency: 0,
+              reserveBeneficiary: zeroAddress,
+              encodedIpfsUri: `0x${"11".repeat(32)}`,
+              category: 0,
+              discountPercent: 0,
+              flags: {},
+              splitPercent: 0,
+              resolvedUri: "",
+            },
+            // Filtered out: initialSupply 0.
+            {
+              id: 2,
+              price: 0n,
+              remainingSupply: 0,
+              initialSupply: 0,
+              votingUnits: 0n,
+              reserveFrequency: 0,
+              reserveBeneficiary: zeroAddress,
+              encodedIpfsUri: `0x${"00".repeat(32)}`,
+              category: 0,
+              discountPercent: 0,
+              flags: {},
+              splitPercent: 0,
+              resolvedUri: "",
+            },
+          ];
+        }
+        throw new Error(`unexpected read ${functionName}`);
+      },
+    } as unknown as PublicClient;
+
+    const shop = await getProject721Shop(client, {
+      chainId,
+      projectId: 1n,
+      isRevnet: true,
+    });
+
+    expect(shop).not.toBeNull();
+    expect(shop!.hook).toEqual(hook);
+    expect(shop!.store).toEqual(store);
+    expect(shop!.metadataIdTarget).toEqual(impl);
+    expect(shop!.pricing).toEqual({ currency: 61166, decimals: 18 });
+    expect(shop!.tiers).toHaveLength(1);
+    expect(shop!.tiers[0]).toMatchObject({ id: 1, price: 1000n });
+  });
+});

--- a/packages/core/src/v6/nft.test.ts
+++ b/packages/core/src/v6/nft.test.ts
@@ -1,5 +1,7 @@
-import { PublicClient, zeroAddress } from "viem";
+import { Address, PublicClient, zeroAddress } from "viem";
 import { describe, expect, test } from "vitest";
+import { JBOmnichainDeployerContracts } from "../contracts.js";
+import { jbContractAddress } from "../generated/juicebox.js";
 import {
   DISCOUNT_DENOMINATOR,
   effectiveTierPrice,
@@ -132,5 +134,112 @@ describe("getProject721Shop", () => {
     expect(shop!.pricing).toEqual({ currency: 61166, decimals: 18 });
     expect(shop!.tiers).toHaveLength(1);
     expect(shop!.tiers[0]).toMatchObject({ id: 1, price: 1000n });
+  });
+
+  const tiersOfOne = () => [
+    {
+      id: 1,
+      price: 1000n,
+      remainingSupply: 5,
+      initialSupply: 10,
+      votingUnits: 0n,
+      reserveFrequency: 0,
+      reserveBeneficiary: zeroAddress,
+      encodedIpfsUri: `0x${"11".repeat(32)}`,
+      category: 0,
+      discountPercent: 0,
+      flags: {},
+      splitPercent: 0,
+      resolvedUri: "",
+    },
+  ];
+
+  // The custom-project omnichain deployer address on chain 11155111, read from
+  // the SDK's own address book so the branch matches real wiring.
+  const omniDeployer = (
+    jbContractAddress["6"][
+      JBOmnichainDeployerContracts.JBOmnichainDeployer
+    ] as Record<string, Address>
+  )["11155111"];
+
+  test("custom project: resolves the real hook via the omnichain deployer", async () => {
+    const client = {
+      readContract: async ({
+        address,
+        functionName,
+      }: {
+        address: string;
+        functionName: string;
+      }) => {
+        // currentRulesetOf -> [ruleset, metadata] with the deployer as data hook.
+        if (functionName === "currentRulesetOf") {
+          return [
+            { id: 7 },
+            { useDataHookForPay: true, dataHook: omniDeployer },
+          ];
+        }
+        // The deployer maps to the real clone hook.
+        if (
+          address.toLowerCase() === omniDeployer.toLowerCase() &&
+          functionName === "tiered721HookOf"
+        ) {
+          return [hook, false];
+        }
+        if (address === hook && functionName === "STORE") return store;
+        if (functionName === "METADATA_ID_TARGET") return impl;
+        if (functionName === "pricingContext") return [1n, 18n];
+        if (functionName === "tiersOf") return tiersOfOne();
+        throw new Error(`unexpected read ${functionName} @ ${address}`);
+      },
+    } as unknown as PublicClient;
+
+    const shop = await getProject721Shop(client, {
+      chainId: 11155111,
+      projectId: 9n,
+      isRevnet: false,
+    });
+    expect(shop!.hook).toEqual(hook);
+    expect(shop!.metadataIdTarget).toEqual(impl);
+  });
+
+  test("custom project: data hook that is not a 721 hook is no shop", async () => {
+    const notAHook = "0x4444444444444444444444444444444444444444" as const;
+    const client = {
+      readContract: async ({ functionName }: { functionName: string }) => {
+        if (functionName === "currentRulesetOf") {
+          return [{ id: 7 }, { useDataHookForPay: true, dataHook: notAHook }];
+        }
+        // Non-authoritative candidate: STORE() reverts => not a 721 hook.
+        if (functionName === "STORE") throw new Error("no STORE");
+        throw new Error(`unexpected read ${functionName}`);
+      },
+    } as unknown as PublicClient;
+
+    expect(
+      await getProject721Shop(client, {
+        chainId: 11155111,
+        projectId: 9n,
+        isRevnet: false,
+      }),
+    ).toBeNull();
+  });
+
+  test("custom project: no pay data hook is no shop", async () => {
+    const client = {
+      readContract: async ({ functionName }: { functionName: string }) => {
+        if (functionName === "currentRulesetOf") {
+          return [{ id: 7 }, { useDataHookForPay: false, dataHook: zeroAddress }];
+        }
+        throw new Error(`unexpected read ${functionName}`);
+      },
+    } as unknown as PublicClient;
+
+    expect(
+      await getProject721Shop(client, {
+        chainId: 11155111,
+        projectId: 9n,
+        isRevnet: false,
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/core/src/v6/nft.ts
+++ b/packages/core/src/v6/nft.ts
@@ -1,0 +1,232 @@
+import { Address, Hex, PublicClient, zeroAddress } from "viem";
+import { JBOmnichainDeployerContracts } from "../contracts.js";
+import {
+  jb721TiersHookAbi,
+  jb721TiersHookStoreAbi,
+  jbContractAddress,
+  jbOmnichainDeployerAbi,
+} from "../generated/juicebox.js";
+import { JBChainId } from "../types.js";
+import { getRevnetTiered721Hook } from "./revnets.js";
+import { getCurrentRuleset } from "./rulesets.js";
+
+/**
+ * JB721TiersHookStore's `DISCOUNT_DENOMINATOR`: a tier's `discountPercent` is
+ * out of 200, so the shopper-facing "% off" is `discountPercent / 2`.
+ */
+export const DISCOUNT_DENOMINATOR = 200n;
+
+/**
+ * A tier's effective (discounted) price, matching the on-chain formula in
+ * JB721TiersHookStore: `price - mulDiv(price, discountPercent, 200)` with
+ * integer-floor division.
+ *
+ * @param price The tier's full (undiscounted) price.
+ * @param discountPercent The tier's discount, out of 200 (`DISCOUNT_DENOMINATOR`).
+ */
+export function effectiveTierPrice(
+  price: bigint,
+  discountPercent: number | bigint,
+): bigint {
+  let discount = BigInt(discountPercent);
+  if (discount <= 0n) return price;
+  if (discount > DISCOUNT_DENOMINATOR) discount = DISCOUNT_DENOMINATOR;
+  return price - (price * discount) / DISCOUNT_DENOMINATOR;
+}
+
+/**
+ * A single 721 tier a project sells.
+ */
+export interface Project721Tier {
+  id: number;
+  /** Full (undiscounted) price in the shop's pricing terms. */
+  price: bigint;
+  remainingSupply: number;
+  initialSupply: number;
+  votingUnits: bigint;
+  reserveFrequency: number;
+  category: number;
+  /** Out of 200 — see {@link DISCOUNT_DENOMINATOR}. */
+  discountPercent: number;
+  encodedIpfsUri: Hex;
+  /** tokenUriResolver output (data URI), or "" if the hook has no resolver. */
+  resolvedUri: string;
+}
+
+/**
+ * A project's resolved 721 tiers hook ("shop"): the hook, its store, the
+ * metadata id target for pay/cash-out metadata, the pricing context, and tiers.
+ */
+export interface Project721Shop {
+  /** The project's 721 tiers hook (the ruleset data hook / revnet hook). */
+  hook: Address;
+  /** The hook's tiers store. */
+  store: Address;
+  /**
+   * The hook's `METADATA_ID_TARGET` (shared implementation address). Pass this
+   * to {@link build721PayMetadata} / {@link build721CashOutMetadata}, never the
+   * `hook` address.
+   */
+  metadataIdTarget: Address;
+  /** The hook's pricing context: `currency` id and `decimals`. */
+  pricing: { currency: number; decimals: number };
+  tiers: Project721Tier[];
+}
+
+/**
+ * Read a JB721 hook's `METADATA_ID_TARGET` — the shared *implementation* address
+ * that pay/cash-out metadata ids must key off (a delegatecall clone reports the
+ * implementation, not itself). Falls back to `hook` if the read reverts (e.g. an
+ * older hook without the getter), which is only correct for a non-clone hook.
+ *
+ * @param client A viem public client on the given chain.
+ * @param args.hook The project's 721 tiers hook (clone) address.
+ */
+export async function get721MetadataIdTarget(
+  client: PublicClient,
+  { hook }: { chainId: JBChainId; hook: Address },
+): Promise<Address> {
+  return client
+    .readContract({
+      address: hook,
+      abi: jb721TiersHookAbi,
+      functionName: "METADATA_ID_TARGET",
+    })
+    .catch(() => hook);
+}
+
+/**
+ * Resolve a project's 721 tiers hook, its store, metadata id target, pricing
+ * context, and tiers in one call.
+ *
+ * Hook resolution mirrors the app patterns: revnets read
+ * `REVOwner.tiered721HookOf`; custom projects read the current ruleset's pay
+ * data hook — either the omnichain deployer (the real hook lives in
+ * `JBOmnichainDeployer.tiered721HookOf(projectId, rulesetId)`) or the 721 hook
+ * itself, verified by probing `STORE()` (a revert means it is not a 721 hook, so
+ * the project has no shop).
+ *
+ * Returns `null` when the project authoritatively has no 721 shop. RPC failures
+ * on authoritative reads throw, so a transient error surfaces as an error rather
+ * than a false "no shop".
+ *
+ * @param client A viem public client on the given chain.
+ * @param args.projectId The project (or revnet) id.
+ * @param args.isRevnet Whether the project is a revnet (changes hook resolution).
+ * @param args.tierLimit Max tiers to read from `tiersOf`. Defaults to 100.
+ * @param args.categories Tier categories to filter by (empty = all). Defaults to `[]`.
+ */
+export async function getProject721Shop(
+  client: PublicClient,
+  {
+    chainId,
+    projectId,
+    isRevnet,
+    tierLimit = 100,
+    categories = [],
+  }: {
+    chainId: JBChainId;
+    projectId: bigint;
+    isRevnet: boolean;
+    tierLimit?: number;
+    categories?: bigint[];
+  },
+): Promise<Project721Shop | null> {
+  // 1. Resolve the 721 hook.
+  let hook: Address | null = null;
+  // A non-authoritative candidate is the ruleset data hook, which might be some
+  // other kind of hook; the STORE() probe below decides.
+  let authoritative = true;
+
+  if (isRevnet) {
+    const revnetHook = await getRevnetTiered721Hook(client, {
+      chainId,
+      revnetId: projectId,
+    });
+    hook = revnetHook !== zeroAddress ? revnetHook : null;
+  } else {
+    const { ruleset, metadata } = await getCurrentRuleset(client, {
+      chainId,
+      projectId,
+    });
+    const dataHook = metadata.dataHook as Address;
+    if (metadata.useDataHookForPay && dataHook && dataHook !== zeroAddress) {
+      const omni = jbContractAddress["6"][
+        JBOmnichainDeployerContracts.JBOmnichainDeployer
+      ]?.[chainId] as Address | undefined;
+      if (omni && dataHook.toLowerCase() === omni.toLowerCase()) {
+        // Omnichain project: the real 721 hook lives in the deployer's
+        // per-ruleset mapping.
+        const [omniHook] = await client.readContract({
+          address: omni,
+          abi: jbOmnichainDeployerAbi,
+          functionName: "tiered721HookOf",
+          args: [projectId, BigInt(ruleset.id)],
+        });
+        hook = omniHook !== zeroAddress ? omniHook : null;
+      } else {
+        // Single-chain custom project: the data hook may be the 721 hook itself.
+        hook = dataHook;
+        authoritative = false;
+      }
+    }
+  }
+  if (!hook) return null;
+
+  // 2. The hook's store. For a non-authoritative candidate a revert means "not a
+  // 721 hook" (no shop); for an authoritative one, let failures throw.
+  const readStore = () =>
+    client.readContract({
+      address: hook!,
+      abi: jb721TiersHookAbi,
+      functionName: "STORE",
+    });
+  const store = authoritative
+    ? await readStore()
+    : await readStore().catch(() => null);
+  if (!store) return null;
+
+  // 3. Metadata id target + pricing context. Pricing is meaningless without the
+  // hook's exact currency + decimals, so a failure here is an error, not a
+  // fallback.
+  const [metadataIdTarget, pricingRaw] = await Promise.all([
+    get721MetadataIdTarget(client, { chainId, hook }),
+    client.readContract({
+      address: hook,
+      abi: jb721TiersHookAbi,
+      functionName: "pricingContext",
+    }),
+  ]);
+
+  // 4. The tiers, with resolver URIs included so callers can name tiers without
+  // a per-tier resolver read.
+  const raw = await client.readContract({
+    address: store,
+    abi: jb721TiersHookStoreAbi,
+    functionName: "tiersOf",
+    args: [hook, categories, true, 0n, BigInt(tierLimit)],
+  });
+
+  const tiers: Project721Tier[] = raw
+    .filter((tier) => tier.initialSupply > 0)
+    .map((tier) => ({
+      id: tier.id,
+      price: tier.price,
+      remainingSupply: tier.remainingSupply,
+      initialSupply: tier.initialSupply,
+      votingUnits: tier.votingUnits,
+      reserveFrequency: tier.reserveFrequency,
+      category: tier.category,
+      discountPercent: tier.discountPercent,
+      encodedIpfsUri: tier.encodedIpfsUri,
+      resolvedUri: tier.resolvedUri ?? "",
+    }));
+
+  return {
+    hook,
+    store,
+    metadataIdTarget,
+    pricing: { currency: Number(pricingRaw[0]), decimals: Number(pricingRaw[1]) },
+    tiers,
+  };
+}

--- a/packages/core/src/v6/pay.test.ts
+++ b/packages/core/src/v6/pay.test.ts
@@ -149,4 +149,17 @@ describe("pay", () => {
     // 0xadc75680 (first 4 bytes of keccak256("pay")) XOR 0x11111111.
     expect(sliceHex(metadata, 32, 36)).toEqual("0xbcd64791");
   });
+
+  test("build721PayMetadata metadataIdTarget matches the hookAddress alias", () => {
+    const target = "0x1111111111111111111111111111111111111111" as const;
+    expect(
+      build721PayMetadata({ metadataIdTarget: target, tierIdsToMint: [1n] }),
+    ).toEqual(build721PayMetadata({ hookAddress: target, tierIdsToMint: [1n] }));
+  });
+
+  test("build721PayMetadata throws when no target is given", () => {
+    expect(() => build721PayMetadata({ tierIdsToMint: [1n] })).toThrow(
+      /metadataIdTarget/,
+    );
+  });
 });

--- a/packages/core/src/v6/pay.ts
+++ b/packages/core/src/v6/pay.ts
@@ -2,15 +2,12 @@ import {
   Address,
   Hex,
   PublicClient,
-  bytesToHex,
   encodeAbiParameters,
-  keccak256,
-  toBytes,
 } from "viem";
 import { DEFAULT_ALLOW_OVERSPENDING, NATIVE_TOKEN } from "../constants.js";
 import { jbMultiTerminalAbi } from "../generated/juicebox.js";
 import { JBChainId } from "../types.js";
-import { createHookMetadata } from "../utils/hook.js";
+import { createHookMetadata, hookMetadataId } from "../utils/hook.js";
 
 /**
  * A prepared `pay` transaction request, accepted as-is by viem's
@@ -153,51 +150,49 @@ export async function previewPay(
 }
 
 /**
- * The metadata id a JB721 hook looks up in pay metadata:
- * `bytes4(bytes20(target) ^ bytes20(keccak256("pay")))`, where the target is the hook's
- * own address (`JB721Hook.METADATA_ID_TARGET` is `address(this)`).
- *
- * @link https://github.com/Bananapus/nana-core-v6/blob/main/src/libraries/JBMetadataResolver.sol (`getId`)
- */
-function pay721MetadataId(hookAddress: Address): Hex {
-  const targetBytes = toBytes(hookAddress).slice(0, 20);
-  const purposeBytes = toBytes(keccak256(toBytes("pay"))).slice(0, 20);
-
-  const xorResult = targetBytes.map((byte, i) => byte ^ purposeBytes[i]);
-
-  return bytesToHex(xorResult.slice(0, 4));
-}
-
-/**
  * Build pay metadata instructing a project's JB721 tiers hook to mint specific tiers.
  *
  * The tier payload is `abi.encode(bool allowOverspending, uint16[] tierIdsToMint)`,
- * keyed by the hook's metadata id (`bytes4(bytes20(hookAddress) ^
+ * keyed by the hook's metadata id (`bytes4(bytes20(metadataIdTarget) ^
  * bytes20(keccak256("pay")))`) and packed into the JBMetadataResolver
  * word-offset-table format.
  *
- * @param args.hookAddress The project's JB721 tiers hook (the ruleset's data hook).
+ * @param args.metadataIdTarget The hook's `METADATA_ID_TARGET` — the shared
+ * *implementation* address, NOT the project's clone hook address (see
+ * {@link get721MetadataIdTarget}). Passing the clone address makes the hook ignore
+ * the tiers and the payment mints ZERO NFTs (it succeeds, minting only tokens).
+ * @param args.hookAddress Deprecated alias for `metadataIdTarget`. Only correct
+ * when it already holds `METADATA_ID_TARGET`; prefer `metadataIdTarget`.
  * @param args.tierIdsToMint The tier ids to mint, one entry per NFT.
  * @param args.allowOverspending Whether payment beyond the tiers' total price is
- * allowed (excess mints no NFT). Defaults to true.
+ * allowed (excess mints no NFT). Defaults to true. Note the hook still gates this
+ * on its store's `preventOverspending` flag.
  * @returns The metadata to pass as `pay`'s `metadata` argument.
  */
 export function build721PayMetadata({
+  metadataIdTarget,
   hookAddress,
   tierIdsToMint,
   allowOverspending = DEFAULT_ALLOW_OVERSPENDING,
 }: {
-  hookAddress: Address;
+  metadataIdTarget?: Address;
+  /** @deprecated Use `metadataIdTarget`. */
+  hookAddress?: Address;
   tierIdsToMint: bigint[];
   allowOverspending?: boolean;
 }): Hex {
+  const target = metadataIdTarget ?? hookAddress;
+  if (!target) {
+    throw new Error("build721PayMetadata requires metadataIdTarget");
+  }
+
   const tierPayload = encodeAbiParameters(
     [{ type: "bool" }, { type: "uint16[]" }],
     [allowOverspending, tierIdsToMint.map(Number)],
   );
 
   return createHookMetadata(
-    [pay721MetadataId(hookAddress)],
+    [hookMetadataId(target, "pay")],
     [tierPayload],
   ) as Hex;
 }

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -2,6 +2,8 @@ export * from "./usePreparePayMetadata";
 export * from "./useNetwork";
 export * from "./jb721Hook/useFind721DataHook";
 export * from "./suckers/useSuckers";
+export * from "./shop/useShopPurchases";
+export * from "./shop/useOwnedShopItems";
 export * from "./token/useNativeTokenSurplus";
 export * from "./token/useNativeTokenSymbol";
 export * from "./token/useSuckersNativeTokenSurplus";

--- a/packages/react/src/hooks/shop/useOwnedShopItems.ts
+++ b/packages/react/src/hooks/shop/useOwnedShopItems.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useMemo } from "react";
+import { useJBChainId } from "../../contexts/JBChainContext/JBChainContext";
+import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
+import {
+  OwnedShopItemsDocument,
+  type OwnedShopItem,
+} from "../../lib/bendystraw/queries/shop";
+import { useBendystrawQuery } from "../../lib/bendystraw/useBendystrawQuery";
+
+/**
+ * The 721 store items `owner` currently holds for the project in context,
+ * newest first — the basis for a redeem/cash-out list. Reads bendystraw `nfts`
+ * for the context chain.
+ *
+ * The index can lag chain state, so verify ownership on-chain (`ownerOf`) before
+ * offering or sending a redemption.
+ *
+ * @param args.owner The holder whose items to list. The query is disabled until set.
+ * @param args.limit Page size. Defaults to 100.
+ * @param args.offset Page offset for pagination. Defaults to 0.
+ * @param args.enabled Whether to run the query. Defaults to true.
+ */
+export function useOwnedShopItems(args: {
+  owner: string | undefined;
+  limit?: number;
+  offset?: number;
+  enabled?: boolean;
+}) {
+  const { owner, limit = 100, offset = 0, enabled = true } = args;
+  const { projectId, version } = useJBContractContext();
+  const chainId = useJBChainId();
+
+  const { data, ...rest } = useBendystrawQuery(
+    OwnedShopItemsDocument,
+    {
+      where: {
+        projectId: Number(projectId),
+        chainId: Number(chainId),
+        version: Number(version),
+        owner: (owner ?? "").toLowerCase(),
+      },
+      limit,
+      offset,
+    },
+    { enabled: !!chainId && !!projectId && !!owner && enabled },
+  );
+
+  const items: OwnedShopItem[] | undefined = useMemo(
+    () =>
+      data?.nfts.items.map((item) => ({
+        chainId: Number(item.chainId),
+        projectId: Number(item.projectId),
+        createdAt: Number(item.createdAt),
+        mintTx: item.mintTx,
+        hook: item.hook?.address ?? "",
+        tokenId: String(item.tokenId),
+        owner: String(item.owner).toLowerCase(),
+        tierId: Number(item.tierId),
+      })),
+    [data],
+  );
+
+  return {
+    data: items,
+    totalCount: data?.nfts.totalCount,
+    ...rest,
+  };
+}

--- a/packages/react/src/hooks/shop/useShopPurchases.ts
+++ b/packages/react/src/hooks/shop/useShopPurchases.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useMemo } from "react";
+import { useJBChainId } from "../../contexts/JBChainContext/JBChainContext";
+import { useJBContractContext } from "../../contexts/JBContractContext/JBContractContext";
+import {
+  ShopPurchasesDocument,
+  type ShopPurchase,
+} from "../../lib/bendystraw/queries/shop";
+import { useBendystrawQuery } from "../../lib/bendystraw/useBendystrawQuery";
+
+/**
+ * Store-item purchases (721 tier mints) for the project in context, newest
+ * first — the "customers" feed. Reads bendystraw `mintNftEvents` for the
+ * context chain.
+ *
+ * @param args.beneficiary Only purchases whose beneficiary is this address (the
+ * connected wallet's own purchases). Omit for all buyers.
+ * @param args.limit Page size. Defaults to 100.
+ * @param args.offset Page offset for pagination. Defaults to 0.
+ * @param args.enabled Whether to run the query. Defaults to true.
+ */
+export function useShopPurchases(args?: {
+  beneficiary?: string;
+  limit?: number;
+  offset?: number;
+  enabled?: boolean;
+}) {
+  const { beneficiary, limit = 100, offset = 0, enabled = true } = args ?? {};
+  const { projectId, version } = useJBContractContext();
+  const chainId = useJBChainId();
+
+  const { data, ...rest } = useBendystrawQuery(
+    ShopPurchasesDocument,
+    {
+      where: {
+        projectId: Number(projectId),
+        chainId: Number(chainId),
+        version: Number(version),
+        ...(beneficiary ? { beneficiary: beneficiary.toLowerCase() } : {}),
+      },
+      limit,
+      offset,
+    },
+    { enabled: !!chainId && !!projectId && enabled },
+  );
+
+  const purchases: ShopPurchase[] | undefined = useMemo(
+    () =>
+      data?.mintNftEvents.items.map((item) => ({
+        ...item,
+        chainId: Number(item.chainId),
+        projectId: Number(item.projectId),
+        timestamp: Number(item.timestamp),
+        tierId: Number(item.tierId),
+        tokenId: String(item.tokenId),
+        totalAmountPaid: String(item.totalAmountPaid),
+      })),
+    [data],
+  );
+
+  return {
+    data: purchases,
+    totalCount: data?.mintNftEvents.totalCount,
+    ...rest,
+  };
+}

--- a/packages/react/src/lib/bendystraw/queries/shop.ts
+++ b/packages/react/src/lib/bendystraw/queries/shop.ts
@@ -1,0 +1,114 @@
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { parse } from "graphql";
+
+/**
+ * Hand-written typed documents for the 721 "shop" bendystraw queries, kept out
+ * of the codegen'd `graphql.ts` so they can be added without refreshing the
+ * whole generated schema. The field selections match the deployed
+ * `bendystraw.xyz` schema (`nft.hook` is a relation, hence `hook { address }`).
+ */
+
+/** A store-item purchase (a `mintNftEvent`). */
+export interface ShopPurchase {
+  chainId: number;
+  projectId: number;
+  timestamp: number;
+  txHash: string;
+  beneficiary: string;
+  tierId: number;
+  tokenId: string;
+  totalAmountPaid: string;
+  hook: string;
+}
+
+/** A currently-held store item (an indexed `nft`). */
+export interface OwnedShopItem {
+  chainId: number;
+  projectId: number;
+  createdAt: number;
+  mintTx: string;
+  hook: string;
+  tokenId: string;
+  owner: string;
+  tierId: number;
+}
+
+/** Filter on a bendystraw list query. Only the fields the shop hooks set. */
+export interface ShopEventFilter {
+  projectId?: number;
+  chainId?: number;
+  version?: number;
+  beneficiary?: string;
+  owner?: string;
+}
+
+export interface ShopPurchasesResult {
+  mintNftEvents: {
+    totalCount: number;
+    items: ShopPurchase[];
+  };
+}
+
+export interface OwnedShopItemsResult {
+  nfts: {
+    totalCount: number;
+    items: (Omit<OwnedShopItem, "hook"> & { hook: { address: string } | null })[];
+  };
+}
+
+export interface ShopQueryVariables {
+  where?: ShopEventFilter;
+  limit?: number;
+  offset?: number;
+}
+
+export const ShopPurchasesDocument = parse(/* GraphQL */ `
+  query ShopPurchases($where: mintNftEventFilter, $limit: Int, $offset: Int) {
+    mintNftEvents(
+      where: $where
+      orderBy: "timestamp"
+      orderDirection: "desc"
+      limit: $limit
+      offset: $offset
+    ) {
+      totalCount
+      items {
+        chainId
+        projectId
+        timestamp
+        txHash
+        beneficiary
+        tierId
+        tokenId
+        totalAmountPaid
+        hook
+      }
+    }
+  }
+`) as TypedDocumentNode<ShopPurchasesResult, ShopQueryVariables>;
+
+export const OwnedShopItemsDocument = parse(/* GraphQL */ `
+  query OwnedShopItems($where: nftFilter, $limit: Int, $offset: Int) {
+    nfts(
+      where: $where
+      orderBy: "createdAt"
+      orderDirection: "desc"
+      limit: $limit
+      offset: $offset
+    ) {
+      totalCount
+      items {
+        chainId
+        projectId
+        createdAt
+        mintTx
+        hook {
+          address
+        }
+        tokenId
+        owner
+        tierId
+      }
+    }
+  }
+`) as TypedDocumentNode<OwnedShopItemsResult, ShopQueryVariables>;


### PR DESCRIPTION
## What

Abstracts the JB721 "shop" logic that `juicebox.money` (v6 shell) had built inline into reusable `@bananapus/nana-sdk-core/v6` helpers, so other sites (website/, juicy-vision) get the same primitives — and fixes a latent silent-mint bug in the existing pay-metadata builder.

### New

- **`getProject721Shop(client, { chainId, projectId, isRevnet })`** → `{ hook, store, metadataIdTarget, pricing: { currency, decimals }, tiers[] }`. Resolves the 721 tiers hook (revnets via `REVOwner.tiered721HookOf`; custom projects via the current ruleset's pay data hook, including the omnichain-deployer `tiered721HookOf(projectId, rulesetId)` path, verified by probing `STORE()`). Returns `null` when a project authoritatively has no shop; throws on RPC failure so a transient error never reads as "no shop". This consolidates the two divergent copies of `readShop` in jbm (`ShopTab.tsx` and `PayPanel.tsx`).
- **`get721MetadataIdTarget`**, **`effectiveTierPrice`** (on-chain `price - mulDiv(price, discountPercent, 200)`), **`DISCOUNT_DENOMINATOR`**.
- **`build721CashOutMetadata({ metadataIdTarget, tokenIds })`** — the NFT-redeem mirror of `build721PayMetadata`, reusing the shared metadata packer (jbm had a hand-rolled envelope that could drift from the pay path).

### Fix (footgun)

`build721PayMetadata`'s id must key off the hook's **`METADATA_ID_TARGET`** — which is `address(this)` in the *implementation's* constructor, so every delegatecall clone reports the shared implementation address, not its own. The old param was named `hookAddress` and the docstring said it was "the hook's own address", inviting callers to pass the clone hook — which yields an id the hook never matches, so **the pay succeeds but mints ZERO NFTs** (only tokens). Renamed the param to `metadataIdTarget` (with `hookAddress` kept as a deprecated alias so existing callers keep working), corrected the docs, and added `get721MetadataIdTarget` so the correct target is explicit. The id formula itself is unchanged.

## Contract verification

Read against source, not memory:
- `JBMetadataResolver.getId` = `bytes4(bytes20(target) ^ bytes20(keccak256(purpose)))`.
- `JB721Hook`: `METADATA_ID_TARGET = address(this)` in the abstract constructor (baked into the implementation immutable, shared by clones).
- Pay decode (`JB721TiersHookLib`): `getId("pay", metadataIdTarget)` → `abi.decode(metadata, (bool, uint16[]))`.
- Cash-out decode (`JB721Hook`): `getId("cashOut", METADATA_ID_TARGET)` → `abi.decode(metadata, (uint256[]))`.
- Effective price: `price - mulDiv(price, discountPercent, DISCOUNT_DENOMINATOR=200)` (floor).

## Testing

- 12 new tests (pay alias/throw, cash-out pack + validation, `effectiveTierPrice`, `get721MetadataIdTarget` fallback, `getProject721Shop` revnet + no-shop). 165/165 core tests pass; typecheck + ESM/CJS builds green.
- **Live read against BAN** (mainnet project 4): 68 tiers resolved, and the clone hook (`0x37e3…8B8f`) ≠ `metadataIdTarget` (`0xf4a5…b5Ab`) — confirming the footgun is real and the reader distinguishes them.

## Notes

- **Bendystraw**: no PR needed — peripheralist's deployed schema already exposes the shop fields jbm uses (`mintNftEvents { tierId tokenId hook totalAmountPaid beneficiary }`, `nfts { tierId owner hook }`). Thin react-package hooks over those (`useShopPurchases` / `useOwnedShopItems`) are a reasonable follow-up but need a graphql-codegen run against the live schema, so they're out of scope here.
- Follow-up in jbm once this publishes: delete its local `build721CashOutMetadata` and `readShop` copies in favor of these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)