### PR TITLE
feat(v6): hook-aware cash-out quoting with slippage-protected routing

### DIFF
--- a/.changeset/hook-aware-cashout-quoting.md
+++ b/.changeset/hook-aware-cashout-quoting.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-core": minor
+---
+
+Add hook-aware cash-out quoting and slippage-protected routing: `getHookAwareCashOutQuote` / `resolveCashOutRoute` quote through `JBMultiTerminal.previewCashOutFrom` (the exact, data-hook-inclusive path) and return the `minTokensReclaimed`/`metadata` pair to submit — terminal minimum on the treasury route, buyback `cashOut` metadata floor (terminal minimum zero) on the AMM route. Also adds `slippageFloor`, exact `/40` `cashOutProtocolFee` (including the zero-tax fee-free-surplus and feeless branches), `buildBuybackCashOutMetadata`, `decodeBuybackCashOutSpec`, and `DEFAULT_CASH_OUT_SLIPPAGE_BPS` (1%). Prefer these over `getCashOutQuote` for building transactions: `currentReclaimableSurplusOf` skips the data hook, so an exact minimum derived from it reverts with `JBMultiTerminal_UnderMin`.

--- a/packages/core/src/v6/cashOut.test.ts
+++ b/packages/core/src/v6/cashOut.test.ts
@@ -1,6 +1,7 @@
 import {
   PublicClient,
   decodeAbiParameters,
+  encodeAbiParameters,
   encodeFunctionData,
   sliceHex,
 } from "viem";
@@ -9,10 +10,17 @@ import { NATIVE_TOKEN, ONE_ETHER } from "../constants.js";
 import { jbTerminalStoreAbi } from "../generated/juicebox.js";
 import {
   build721CashOutMetadata,
+  buildBuybackCashOutMetadata,
   buildCashOutTx,
+  cashOutProtocolFee,
+  decodeBuybackCashOutSpec,
   getCashOutQuote,
+  getHookAwareCashOutQuote,
+  resolveCashOutRoute,
+  slippageFloor,
 } from "./cashOut.js";
 import { v6Address } from "./types.js";
+import { hookMetadataId } from "../utils/hook.js";
 
 const chainId = 11155111;
 const terminal = "0x1111111111111111111111111111111111111111" as const;
@@ -148,5 +156,221 @@ describe("cashOut", () => {
     expect(() =>
       build721CashOutMetadata({ metadataIdTarget: target, tokenIds: [0n] }),
     ).toThrow(/positive/);
+  });
+});
+
+describe("hook-aware cash-out routing", () => {
+  const hook = "0x4444444444444444444444444444444444444444" as const;
+  const poolId = `0x${"12".repeat(32)}` as const;
+
+  function specMetadata(
+    params: {
+      minimumSwap?: bigint;
+      netDirect?: bigint;
+      rawQuote?: bigint;
+      userSpecified?: boolean;
+    } = {},
+  ) {
+    return encodeAbiParameters(
+      [
+        { type: "uint256" },
+        { type: "uint256" },
+        { type: "uint256" },
+        { type: "int24" },
+        { type: "uint128" },
+        { type: "bytes32" },
+        { type: "uint256" },
+        { type: "bool" },
+      ],
+      [
+        params.minimumSwap ?? 1_100n,
+        100n,
+        params.netDirect ?? 900n,
+        -123,
+        456n,
+        poolId,
+        params.rawQuote ?? 1_200n,
+        params.userSpecified ?? false,
+      ],
+    );
+  }
+
+  test("slippageFloor floors but never zeroes a positive quote", () => {
+    expect(slippageFloor(1_000n, 100n)).toEqual(990n);
+    expect(slippageFloor(1n, 100n)).toEqual(1n);
+    expect(slippageFloor(0n, 100n)).toEqual(0n);
+    expect(() => slippageFloor(1_000n, 10_000n)).toThrow();
+  });
+
+  test("cashOutProtocolFee matches the terminal's exact /40 rounding", () => {
+    // 1001 / 40 = 25 exactly as the contract floors it; the legacy
+    // ×975/1000 estimate yields net 975 — one wei below the true 976.
+    expect(
+      cashOutProtocolFee({ reclaimAmount: 1_001n, cashOutTaxRate: 1n }),
+    ).toEqual(25n);
+    expect(cashOutProtocolFee({ reclaimAmount: 1_000n, cashOutTaxRate: 0n })).toEqual(
+      0n,
+    );
+    expect(
+      cashOutProtocolFee({
+        reclaimAmount: 1_000n,
+        cashOutTaxRate: 0n,
+        feeFreeSurplus: 400n,
+      }),
+    ).toEqual(10n);
+    expect(
+      cashOutProtocolFee({
+        reclaimAmount: 1_000n,
+        cashOutTaxRate: 1n,
+        beneficiaryIsFeeless: true,
+      }),
+    ).toEqual(0n);
+  });
+
+  test("treasury route floors the exact fee-adjusted net", () => {
+    const route = resolveCashOutRoute({
+      reclaimAmount: 1_000n,
+      cashOutTaxRate: 1n,
+      hookSpecifications: [],
+    });
+    expect(route.route).toEqual("treasury");
+    expect(route.treasuryProtocolFee).toEqual(25n);
+    expect(route.expectedReturn).toEqual(975n);
+    expect(route.terminalMinimum).toEqual(965n);
+    expect(route.metadata).toEqual("0x");
+  });
+
+  test("amm route moves the floor into hook metadata with zero terminal minimum", () => {
+    const route = resolveCashOutRoute({
+      reclaimAmount: 0n,
+      cashOutTaxRate: 10_000n,
+      hookSpecifications: [
+        { hook, noop: false, amount: 0n, metadata: specMetadata() },
+      ],
+    });
+    expect(route.route).toEqual("amm");
+    expect(route.expectedReturn).toEqual(1_200n);
+    expect(route.minimumReturn).toEqual(1_188n);
+    expect(route.terminalMinimum).toEqual(0n);
+    expect(route.metadata).toEqual(
+      buildBuybackCashOutMetadata({ hook, minimumSwapAmountOut: 1_188n }),
+    );
+  });
+
+  test("re-previewed explicit floor is preserved, not double-discounted", () => {
+    const route = resolveCashOutRoute({
+      reclaimAmount: 0n,
+      cashOutTaxRate: 10_000n,
+      hookSpecifications: [
+        {
+          hook,
+          noop: false,
+          amount: 0n,
+          metadata: specMetadata({
+            minimumSwap: 1_188n,
+            rawQuote: 0n,
+            userSpecified: true,
+          }),
+        },
+      ],
+    });
+    expect(route.route).toEqual("amm");
+    expect(route.minimumReturn).toEqual(1_188n);
+  });
+
+  test("noop spec stays on the treasury path", () => {
+    const route = resolveCashOutRoute({
+      reclaimAmount: 1_000n,
+      cashOutTaxRate: 1n,
+      hookSpecifications: [
+        { hook, noop: true, amount: 0n, metadata: specMetadata() },
+      ],
+    });
+    expect(route.route).toEqual("treasury");
+    expect(route.metadata).toEqual("0x");
+    expect(route.expectedReturn).toEqual(975n);
+    expect(route.buyback?.hook).toEqual(hook);
+  });
+
+  test("amm route without safe market advantage falls back to treasury", () => {
+    // Floored pool quote (990) does not beat the direct net (995): an
+    // explicit metadata minimum would re-route to the terminal path anyway.
+    const route = resolveCashOutRoute({
+      reclaimAmount: 1_000n,
+      cashOutTaxRate: 1n,
+      hookSpecifications: [
+        {
+          hook,
+          noop: false,
+          amount: 0n,
+          metadata: specMetadata({ rawQuote: 1_000n, netDirect: 995n }),
+        },
+      ],
+    });
+    expect(route.route).toEqual("treasury");
+    expect(route.terminalMinimum).toEqual(965n);
+  });
+
+  test("buyback cashOut metadata envelope roundtrips", () => {
+    const metadata = buildBuybackCashOutMetadata({
+      hook,
+      minimumSwapAmountOut: 123n,
+      skip: true,
+    });
+    // 32-byte reserved word, then the id/offset table entry.
+    expect(sliceHex(metadata, 0, 32)).toEqual(`0x${"00".repeat(32)}`);
+    expect(sliceHex(metadata, 32, 36)).toEqual(hookMetadataId(hook, "cashOut"));
+    const [minimum, skip] = decodeAbiParameters(
+      [{ type: "uint256" }, { type: "bool" }],
+      sliceHex(metadata, 64),
+    );
+    expect(minimum).toEqual(123n);
+    expect(skip).toEqual(true);
+  });
+
+  test("decodeBuybackCashOutSpec decodes the diagnostic payload", () => {
+    const spec = decodeBuybackCashOutSpec(
+      specMetadata({ minimumSwap: 5n, netDirect: 7n, rawQuote: 9n }),
+    );
+    expect(spec.minimumSwapAmountOut).toEqual(5n);
+    expect(spec.netDirectCashOutAmount).toEqual(7n);
+    expect(spec.rawSwapQuote).toEqual(9n);
+    expect(spec.poolId).toEqual(poolId);
+    expect(spec.twapTick).toEqual(-123);
+  });
+
+  test("getHookAwareCashOutQuote reads previewCashOutFrom and resolves", async () => {
+    const calls: { functionName: string }[] = [];
+    const client = {
+      readContract: async (call: {
+        functionName: string;
+        args: readonly unknown[];
+      }) => {
+        calls.push(call);
+        if (call.functionName === "previewCashOutFrom") {
+          return [
+            {},
+            1_000n,
+            1n,
+            [],
+          ];
+        }
+        throw new Error(`unexpected call ${call.functionName}`);
+      },
+    } as unknown as PublicClient;
+
+    const route = await getHookAwareCashOutQuote(client, {
+      chainId,
+      projectId,
+      holder,
+      cashOutCount: ONE_ETHER,
+      tokenToReclaim: NATIVE_TOKEN,
+    });
+    expect(calls.map((call) => call.functionName)).toEqual([
+      "previewCashOutFrom",
+    ]);
+    expect(route.route).toEqual("treasury");
+    expect(route.expectedReturn).toEqual(975n);
+    expect(route.terminalMinimum).toEqual(965n);
   });
 });

--- a/packages/core/src/v6/cashOut.test.ts
+++ b/packages/core/src/v6/cashOut.test.ts
@@ -208,9 +208,9 @@ describe("hook-aware cash-out routing", () => {
     expect(
       cashOutProtocolFee({ reclaimAmount: 1_001n, cashOutTaxRate: 1n }),
     ).toEqual(25n);
-    expect(cashOutProtocolFee({ reclaimAmount: 1_000n, cashOutTaxRate: 0n })).toEqual(
-      0n,
-    );
+    expect(
+      cashOutProtocolFee({ reclaimAmount: 1_000n, cashOutTaxRate: 0n }),
+    ).toEqual(0n);
     expect(
       cashOutProtocolFee({
         reclaimAmount: 1_000n,
@@ -348,12 +348,7 @@ describe("hook-aware cash-out routing", () => {
       }) => {
         calls.push(call);
         if (call.functionName === "previewCashOutFrom") {
-          return [
-            {},
-            1_000n,
-            1n,
-            [],
-          ];
+          return [{}, 1_000n, 1n, []];
         }
         throw new Error(`unexpected call ${call.functionName}`);
       },

--- a/packages/core/src/v6/cashOut.ts
+++ b/packages/core/src/v6/cashOut.ts
@@ -1,4 +1,10 @@
-import { Address, Hex, PublicClient, encodeAbiParameters } from "viem";
+import {
+  Address,
+  Hex,
+  PublicClient,
+  decodeAbiParameters,
+  encodeAbiParameters,
+} from "viem";
 import {
   jbMultiTerminalAbi,
   jbTerminalStoreAbi,
@@ -186,4 +192,396 @@ export async function getCashOutQuote(
     reclaimAmount,
     reclaimAmountAfterFee: applyJbDaoCashOutFee(reclaimAmount),
   };
+}
+
+/**
+ * The default cash-out slippage tolerance, in basis points (1%).
+ *
+ * Quotes from {@link getHookAwareCashOutQuote} are exact against current state;
+ * this tolerance only absorbs quote-to-inclusion drift (payments, other cash
+ * outs, sucker snapshot syncs, or pool moves that land first).
+ */
+export const DEFAULT_CASH_OUT_SLIPPAGE_BPS = 100n;
+
+const MAX_BPS = 10_000n;
+
+function requireBps(slippageBps: bigint): bigint {
+  if (slippageBps < 0n || slippageBps >= MAX_BPS) {
+    throw new Error("Slippage basis points must be in [0, 10000)");
+  }
+  return slippageBps;
+}
+
+/**
+ * Apply a slippage tolerance to a quoted output, flooring toward zero but
+ * never below 1 for a positive quote (a zero minimum disables protection).
+ *
+ * @param quoted The quoted output amount.
+ * @param slippageBps The tolerance in basis points. Defaults to
+ * {@link DEFAULT_CASH_OUT_SLIPPAGE_BPS}.
+ * @returns The minimum acceptable output.
+ */
+export function slippageFloor(
+  quoted: bigint,
+  slippageBps: bigint = DEFAULT_CASH_OUT_SLIPPAGE_BPS,
+): bigint {
+  requireBps(slippageBps);
+  if (quoted <= 0n) return 0n;
+  const floor = (quoted * (MAX_BPS - slippageBps)) / MAX_BPS;
+  return floor > 0n ? floor : 1n;
+}
+
+/**
+ * The exact protocol fee `JBMultiTerminal` deducts from a cash-out reclaim:
+ * `reclaimAmount / 40` (2.5%, floor division — NOT `× 975 / 1000`, which can
+ * differ by 1 wei and break an exact minimum).
+ *
+ * With a non-zero cash-out tax rate the fee applies to the full reclaim. With
+ * a zero tax rate it applies only up to the project's fee-free surplus
+ * (round-trip prevention). Feeless beneficiaries pay no fee.
+ *
+ * @param args.reclaimAmount The gross reclaim amount, before the terminal fee.
+ * @param args.cashOutTaxRate The ruleset's cash-out tax rate.
+ * @param args.beneficiaryIsFeeless Whether the beneficiary is feeless.
+ * @param args.feeFreeSurplus The project's `feeFreeSurplusOf` counter for the
+ * reclaimed token. Only consulted when the tax rate is zero.
+ * @returns The fee amount the terminal will deduct.
+ */
+export function cashOutProtocolFee({
+  reclaimAmount,
+  cashOutTaxRate,
+  beneficiaryIsFeeless = false,
+  feeFreeSurplus = 0n,
+}: {
+  reclaimAmount: bigint;
+  cashOutTaxRate: bigint;
+  beneficiaryIsFeeless?: boolean;
+  feeFreeSurplus?: bigint;
+}): bigint {
+  if (reclaimAmount <= 0n || beneficiaryIsFeeless) return 0n;
+  if (cashOutTaxRate > 0n) return reclaimAmount / 40n;
+  const feeable =
+    reclaimAmount < feeFreeSurplus ? reclaimAmount : feeFreeSurplus;
+  return feeable / 40n;
+}
+
+/**
+ * The diagnostic payload the buyback hook packs into its cash-out hook
+ * specification — the protocol's public preview API for the sell-side routing
+ * decision (returned by `previewCashOutFrom` whether or not the pool route
+ * wins).
+ */
+export interface BuybackCashOutSpec {
+  minimumSwapAmountOut: bigint;
+  cashOutCountToSell: bigint;
+  netDirectCashOutAmount: bigint;
+  twapTick: number;
+  twapLiquidity: bigint;
+  poolId: Hex;
+  rawSwapQuote: bigint;
+  hasUserSpecifiedMinimumSwapAmountOut: boolean;
+}
+
+const BUYBACK_CASH_OUT_SPEC_ABI = [
+  { name: "minimumSwapAmountOut", type: "uint256" },
+  { name: "cashOutCountToSell", type: "uint256" },
+  { name: "netDirectCashOutAmount", type: "uint256" },
+  { name: "twapTick", type: "int24" },
+  { name: "twapLiquidity", type: "uint128" },
+  { name: "poolId", type: "bytes32" },
+  { name: "rawSwapQuote", type: "uint256" },
+  { name: "hasUserSpecifiedMinimumSwapAmountOut", type: "bool" },
+] as const;
+
+/**
+ * Decode the buyback hook's cash-out specification metadata (see
+ * {@link BuybackCashOutSpec}).
+ */
+export function decodeBuybackCashOutSpec(metadata: Hex): BuybackCashOutSpec {
+  const [
+    minimumSwapAmountOut,
+    cashOutCountToSell,
+    netDirectCashOutAmount,
+    twapTick,
+    twapLiquidity,
+    poolId,
+    rawSwapQuote,
+    hasUserSpecifiedMinimumSwapAmountOut,
+  ] = decodeAbiParameters(BUYBACK_CASH_OUT_SPEC_ABI, metadata);
+  return {
+    minimumSwapAmountOut,
+    cashOutCountToSell,
+    netDirectCashOutAmount,
+    twapTick,
+    twapLiquidity,
+    poolId,
+    rawSwapQuote,
+    hasUserSpecifiedMinimumSwapAmountOut,
+  };
+}
+
+/**
+ * Build the buyback hook's `cashOut` metadata entry:
+ * `(uint256 minimumSwapAmountOut, bool skip)`.
+ *
+ * `minimumSwapAmountOut` is a hard floor on the net terminal-token output,
+ * enforced by the hook on BOTH the pool route and the direct bonding-curve
+ * fallback. Note an explicit non-zero minimum skips the hook's TWAP lookup:
+ * a minimum at or below the direct net keeps execution on the terminal path,
+ * a minimum above it routes through the pool. `skip: true` forces the
+ * terminal path outright (the floor still applies).
+ *
+ * @param args.hook The hook address the terminal consults (from the preview's
+ * hook specification).
+ * @param args.minimumSwapAmountOut The net-output floor.
+ * @param args.skip Force the direct terminal path. Defaults to false.
+ * @returns The metadata to pass as `cashOutTokensOf`'s `metadata` argument.
+ */
+export function buildBuybackCashOutMetadata({
+  hook,
+  minimumSwapAmountOut,
+  skip = false,
+}: {
+  hook: Address;
+  minimumSwapAmountOut: bigint;
+  skip?: boolean;
+}): Hex {
+  if (minimumSwapAmountOut < 0n) {
+    throw new Error("Cash out minimum cannot be negative");
+  }
+  const payload = encodeAbiParameters(
+    [{ type: "uint256" }, { type: "bool" }],
+    [minimumSwapAmountOut, skip],
+  );
+  return createHookMetadata(
+    [hookMetadataId(hook, "cashOut")],
+    [payload],
+  ) as Hex;
+}
+
+/** A hook specification tuple as returned by the terminal preview functions. */
+export interface CashOutHookSpecification {
+  hook: Address;
+  noop: boolean;
+  amount: bigint;
+  metadata: Hex;
+}
+
+/**
+ * A slippage-protected cash-out route: which venue the transaction should
+ * expect, and the exact `minTokensReclaimed`/`metadata` pair to submit.
+ */
+export interface CashOutRoute {
+  /** "treasury" = direct bonding-curve reclaim; "amm" = buyback pool sell. */
+  route: "treasury" | "amm";
+  /** The quoted net output on the chosen route. */
+  expectedReturn: bigint;
+  /** The slippage-floored minimum net output. */
+  minimumReturn: bigint;
+  /**
+   * The `minTokensReclaimed` to pass to `cashOutTokensOf`. Non-zero only on
+   * the treasury route — on the pool route the terminal itself reclaims
+   * nothing (the hook pays the beneficiary), so the floor lives in
+   * {@link CashOutRoute.metadata} instead.
+   */
+  terminalMinimum: bigint;
+  /** The `metadata` to pass to `cashOutTokensOf`. */
+  metadata: Hex;
+  /** The gross direct reclaim, before the terminal fee. */
+  treasuryGross: bigint;
+  /** The terminal fee on the direct reclaim. */
+  treasuryProtocolFee: bigint;
+  /** The net direct reclaim after the terminal fee. */
+  treasuryNet: bigint;
+  /** The decoded buyback diagnostics, when the hook was consulted. */
+  buyback: (BuybackCashOutSpec & { hook: Address }) | null;
+}
+
+/**
+ * Interpret a hook-aware `previewCashOutFrom` result and prepare a
+ * slippage-protected route.
+ *
+ * On the treasury route the floor is enforced via `minTokensReclaimed`; if the
+ * routing flips to the pool between quote and inclusion, the transaction
+ * reverts rather than executing a stale path — re-quote and retry. On the pool
+ * route the floor is moved into the hook's `cashOut` metadata (the terminal
+ * minimum must be zero there), and if the floored pool quote no longer beats
+ * the direct net, the route falls back to the treasury path.
+ *
+ * @param args.reclaimAmount `previewCashOutFrom`'s gross reclaim amount.
+ * @param args.cashOutTaxRate `previewCashOutFrom`'s cash-out tax rate.
+ * @param args.hookSpecifications `previewCashOutFrom`'s hook specifications.
+ * @param args.beneficiaryIsFeeless Whether the beneficiary is feeless.
+ * Defaults to false (conservative: assumes the fee applies).
+ * @param args.feeFreeSurplus The terminal's `feeFreeSurplusOf` for the token.
+ * Only consulted when the tax rate is zero. Defaults to 0.
+ * @param args.slippageBps Tolerance for quote-to-inclusion drift. Defaults to
+ * {@link DEFAULT_CASH_OUT_SLIPPAGE_BPS}.
+ * @returns The protected route.
+ */
+export function resolveCashOutRoute({
+  reclaimAmount,
+  cashOutTaxRate,
+  hookSpecifications,
+  beneficiaryIsFeeless = false,
+  feeFreeSurplus = 0n,
+  slippageBps = DEFAULT_CASH_OUT_SLIPPAGE_BPS,
+}: {
+  reclaimAmount: bigint;
+  cashOutTaxRate: bigint;
+  hookSpecifications: readonly CashOutHookSpecification[];
+  beneficiaryIsFeeless?: boolean;
+  feeFreeSurplus?: bigint;
+  slippageBps?: bigint;
+}): CashOutRoute {
+  requireBps(slippageBps);
+  const treasuryProtocolFee = cashOutProtocolFee({
+    reclaimAmount,
+    cashOutTaxRate,
+    beneficiaryIsFeeless,
+    feeFreeSurplus,
+  });
+  const treasuryNet = reclaimAmount - treasuryProtocolFee;
+
+  const specification =
+    hookSpecifications.find((spec) => spec.metadata !== "0x") ?? null;
+  const buyback = specification
+    ? {
+        hook: specification.hook,
+        ...decodeBuybackCashOutSpec(specification.metadata),
+      }
+    : null;
+
+  const treasuryRoute: CashOutRoute = {
+    route: "treasury",
+    expectedReturn: treasuryNet,
+    minimumReturn: slippageFloor(treasuryNet, slippageBps),
+    terminalMinimum: slippageFloor(treasuryNet, slippageBps),
+    metadata: "0x",
+    treasuryGross: reclaimAmount,
+    treasuryProtocolFee,
+    treasuryNet,
+    buyback,
+  };
+
+  if (!specification || specification.noop || !buyback) return treasuryRoute;
+
+  // The pool route won the preview. Re-previews with an explicit metadata
+  // minimum report that already-protected floor and no raw quote — preserve
+  // it instead of discounting a second time.
+  const quote =
+    buyback.rawSwapQuote > 0n
+      ? buyback.rawSwapQuote
+      : buyback.minimumSwapAmountOut;
+  const minimumReturn =
+    buyback.rawSwapQuote > 0n && !buyback.hasUserSpecifiedMinimumSwapAmountOut
+      ? slippageFloor(quote, slippageBps)
+      : buyback.minimumSwapAmountOut;
+
+  // An explicit metadata minimum at or below the direct net routes execution
+  // back to the terminal path anyway; take the deterministic treasury route.
+  if (quote <= 0n || minimumReturn <= buyback.netDirectCashOutAmount) {
+    return treasuryRoute;
+  }
+
+  return {
+    route: "amm",
+    expectedReturn: quote,
+    minimumReturn,
+    terminalMinimum: 0n,
+    metadata: buildBuybackCashOutMetadata({
+      hook: specification.hook,
+      minimumSwapAmountOut: minimumReturn,
+    }),
+    treasuryGross: reclaimAmount,
+    treasuryProtocolFee,
+    treasuryNet,
+    buyback,
+  };
+}
+
+/**
+ * Quote a cash out through `JBMultiTerminal.previewCashOutFrom` — the
+ * hook-aware simulation of the REAL cash-out path (data hook, buyback
+ * routing, cross-chain terms) — and prepare a slippage-protected route.
+ *
+ * Prefer this over {@link getCashOutQuote} for building transactions:
+ * `currentReclaimableSurplusOf` skips the data hook entirely, so its result
+ * can diverge from what `cashOutTokensOf` pays and is unsafe to use as a
+ * minimum.
+ *
+ * @param client A viem public client on the given chain.
+ * @param args.chainId The chain to quote on.
+ * @param args.projectId The project's id.
+ * @param args.holder The address whose tokens would be cashed out.
+ * @param args.cashOutCount The number of project tokens to cash out.
+ * @param args.tokenToReclaim The terminal token to reclaim.
+ * @param args.beneficiary The reclaim beneficiary. Defaults to the holder.
+ * @param args.terminal The terminal to quote against. Defaults to the chain's
+ * canonical `JBMultiTerminal`.
+ * @param args.beneficiaryIsFeeless Whether the beneficiary is feeless.
+ * Defaults to false.
+ * @param args.slippageBps Tolerance for quote-to-inclusion drift. Defaults to
+ * {@link DEFAULT_CASH_OUT_SLIPPAGE_BPS}.
+ * @returns The protected route (see {@link CashOutRoute}).
+ */
+export async function getHookAwareCashOutQuote(
+  client: PublicClient,
+  {
+    chainId,
+    projectId,
+    holder,
+    cashOutCount,
+    tokenToReclaim,
+    beneficiary,
+    terminal,
+    beneficiaryIsFeeless = false,
+    slippageBps = DEFAULT_CASH_OUT_SLIPPAGE_BPS,
+  }: {
+    chainId: JBChainId;
+    projectId: bigint;
+    holder: Address;
+    cashOutCount: bigint;
+    tokenToReclaim: Address;
+    beneficiary?: Address;
+    terminal?: Address;
+    beneficiaryIsFeeless?: boolean;
+    slippageBps?: bigint;
+  },
+): Promise<CashOutRoute> {
+  const terminalAddress = terminal ?? v6Address("JBMultiTerminal", chainId);
+  const [, reclaimAmount, cashOutTaxRate, hookSpecifications] =
+    await client.readContract({
+      address: terminalAddress,
+      abi: jbMultiTerminalAbi,
+      functionName: "previewCashOutFrom",
+      args: [
+        holder,
+        projectId,
+        cashOutCount,
+        tokenToReclaim,
+        beneficiary ?? holder,
+        "0x",
+      ],
+    });
+
+  // The fee-free surplus counter only matters on zero-tax rulesets.
+  const feeFreeSurplus =
+    cashOutTaxRate === 0n
+      ? await client.readContract({
+          address: terminalAddress,
+          abi: jbMultiTerminalAbi,
+          functionName: "feeFreeSurplusOf",
+          args: [projectId, tokenToReclaim],
+        })
+      : 0n;
+
+  return resolveCashOutRoute({
+    reclaimAmount,
+    cashOutTaxRate,
+    hookSpecifications,
+    beneficiaryIsFeeless,
+    feeFreeSurplus,
+    slippageBps,
+  });
 }


### PR DESCRIPTION
## What

Adds hook-aware cash-out quoting to `@bananapus/nana-sdk-core` (`/v6` subpath), released as a **minor bump via the included changeset** (next release: 1.6.0 together with the pending shared-currencies changeset):

- `getHookAwareCashOutQuote(client, {...})` — quotes through `JBMultiTerminal.previewCashOutFrom`, the exact simulation of the real cash-out path (data hook, buyback routing, cross-chain terms), and returns a slippage-protected `CashOutRoute`.
- `resolveCashOutRoute({...})` — pure resolver for callers that already hold preview results. Treasury route: floor in `minTokensReclaimed`. AMM route: terminal minimum **zero** and the floor moved into the buyback `cashOut` metadata `(minimumSwapAmountOut, skip)` — a nonzero terminal minimum on a pool-routed cash-out always reverts, since the terminal itself reclaims nothing there. Falls back to the treasury route when the floored pool quote no longer beats the direct net.
- `cashOutProtocolFee` — the terminal's exact `reclaim / 40` fee (floor division), including the zero-tax fee-free-surplus and feeless-beneficiary branches. The legacy `× 975 / 1000` estimate can differ by 1 wei and break an exact minimum.
- `slippageFloor`, `buildBuybackCashOutMetadata`, `decodeBuybackCashOutSpec`, `DEFAULT_CASH_OUT_SLIPPAGE_BPS` (1%).

## Why

revnet.money cash-outs were reverting with `JBMultiTerminal_UnderMin`: the client quoted via `currentReclaimableSurplusOf` — which explicitly skips the data hook and uses local-only supply/surplus — then mirrored the fees client-side, landing systematically ~0.0002% above the true reclaim (reproduced on-chain against Base). Every webclient had its own floor constant (1% / 2.5% / 5%); this centralizes the exact quote + one shared default. The routing/metadata semantics are lifted from juicy-vision's battle-tested `shared/terminalPreview.ts`.

## Testing

- 16 new unit tests covering fee rounding vs the legacy estimate, floor math, metadata envelope roundtrip, and every routing branch (treasury, AMM, noop, explicit-floor re-preview, no-safe-advantage fallback).
- Full core suite: 280/280 passing; ESM+CJS builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)