### PR TITLE
fix: match buyback cash-out spec by hook address, not metadata presence

### DIFF
--- a/.changeset/match-buyback-spec-by-hook-address.md
+++ b/.changeset/match-buyback-spec-by-hook-address.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-core": patch
+---
+
+Fix cash-out routing selecting the wrong hook specification as the buyback route: `resolveCashOutRoute` matched "the buyback spec" as the first specification with non-empty metadata, so a spec from any other data hook (e.g. a 721 tiers hook) whose metadata happened to decode could be routed as a pool sell with a zero terminal minimum and a floor keyed to the wrong hook. The buyback spec is now matched by hook address (case-insensitive) via the new optional `buybackHookAddress` argument on `resolveCashOutRoute` and `getHookAwareCashOutQuote`. `getHookAwareCashOutQuote` resolves it automatically from `chainId` (the chain's canonical `JBBuybackHook`) — pass it explicitly only for a project whose `JBBuybackHookRegistry` entry points at a custom hook. Callers using `resolveCashOutRoute` directly must now pass `buybackHookAddress` to get the AMM route; without it every specification is treated as non-buyback and the deterministic treasury route (with its real `minTokensReclaimed` floor) is returned — fail-safe, never a zero-minimum guess.

--- a/packages/core/src/v6/cashOut.test.ts
+++ b/packages/core/src/v6/cashOut.test.ts
@@ -247,6 +247,7 @@ describe("hook-aware cash-out routing", () => {
       hookSpecifications: [
         { hook, noop: false, amount: 0n, metadata: specMetadata() },
       ],
+      buybackHookAddress: hook,
     });
     expect(route.route).toEqual("amm");
     expect(route.expectedReturn).toEqual(1_200n);
@@ -273,6 +274,7 @@ describe("hook-aware cash-out routing", () => {
           }),
         },
       ],
+      buybackHookAddress: hook,
     });
     expect(route.route).toEqual("amm");
     expect(route.minimumReturn).toEqual(1_188n);
@@ -285,6 +287,7 @@ describe("hook-aware cash-out routing", () => {
       hookSpecifications: [
         { hook, noop: true, amount: 0n, metadata: specMetadata() },
       ],
+      buybackHookAddress: hook,
     });
     expect(route.route).toEqual("treasury");
     expect(route.metadata).toEqual("0x");
@@ -306,6 +309,7 @@ describe("hook-aware cash-out routing", () => {
           metadata: specMetadata({ rawQuote: 1_000n, netDirect: 995n }),
         },
       ],
+      buybackHookAddress: hook,
     });
     expect(route.route).toEqual("treasury");
     expect(route.terminalMinimum).toEqual(965n);
@@ -339,6 +343,85 @@ describe("hook-aware cash-out routing", () => {
     expect(spec.twapTick).toEqual(-123);
   });
 
+  test("spec from a non-buyback hook is never selected as the amm route", () => {
+    // A 721 tiers hook (or any other data-hook-returned specification) can
+    // carry metadata that garbage-decodes to plausible buyback values. It must
+    // NOT be routed as a pool sell with a zero terminal minimum.
+    const route = resolveCashOutRoute({
+      reclaimAmount: 1_000n,
+      cashOutTaxRate: 1n,
+      hookSpecifications: [
+        { hook, noop: false, amount: 0n, metadata: specMetadata() },
+      ],
+      buybackHookAddress: "0x5555555555555555555555555555555555555555",
+    });
+    expect(route.route).toEqual("treasury");
+    expect(route.terminalMinimum).toEqual(965n);
+    expect(route.metadata).toEqual("0x");
+    expect(route.buyback).toBeNull();
+  });
+
+  test("without a buyback hook address no spec is trusted as the amm route", () => {
+    const route = resolveCashOutRoute({
+      reclaimAmount: 1_000n,
+      cashOutTaxRate: 1n,
+      hookSpecifications: [
+        { hook, noop: false, amount: 0n, metadata: specMetadata() },
+      ],
+    });
+    expect(route.route).toEqual("treasury");
+    expect(route.terminalMinimum).toEqual(965n);
+    expect(route.metadata).toEqual("0x");
+    expect(route.buyback).toBeNull();
+  });
+
+  test("buyback spec is matched by address, case-insensitively", () => {
+    // Checksummed on-chain hook vs lowercase address-book entry.
+    const checksummed = "0xAbCdaBCDabcDabcdaBcdABCdaBCDAbCDaBcDABcd" as const;
+    const route = resolveCashOutRoute({
+      reclaimAmount: 0n,
+      cashOutTaxRate: 10_000n,
+      hookSpecifications: [
+        {
+          hook: checksummed,
+          noop: false,
+          amount: 0n,
+          metadata: specMetadata(),
+        },
+      ],
+      buybackHookAddress: "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+    });
+    expect(route.route).toEqual("amm");
+    expect(route.terminalMinimum).toEqual(0n);
+    expect(route.buyback?.hook).toEqual(checksummed);
+  });
+
+  test("mixed specs select the buyback one by address, not position", () => {
+    const otherHook = "0x6666666666666666666666666666666666666666" as const;
+    const route = resolveCashOutRoute({
+      reclaimAmount: 0n,
+      cashOutTaxRate: 10_000n,
+      hookSpecifications: [
+        // A non-buyback spec listed first, with metadata that happens to
+        // decode: the legacy first-with-metadata heuristic picked this one.
+        {
+          hook: otherHook,
+          noop: false,
+          amount: 0n,
+          metadata: specMetadata({ rawQuote: 9_999n }),
+        },
+        { hook, noop: false, amount: 0n, metadata: specMetadata() },
+      ],
+      buybackHookAddress: hook,
+    });
+    expect(route.route).toEqual("amm");
+    expect(route.expectedReturn).toEqual(1_200n);
+    expect(route.buyback?.hook).toEqual(hook);
+    expect(route.metadata).toEqual(
+      buildBuybackCashOutMetadata({ hook, minimumSwapAmountOut: 1_188n }),
+    );
+  });
+
   test("getHookAwareCashOutQuote reads previewCashOutFrom and resolves", async () => {
     const calls: { functionName: string }[] = [];
     const client = {
@@ -367,5 +450,58 @@ describe("hook-aware cash-out routing", () => {
     expect(route.route).toEqual("treasury");
     expect(route.expectedReturn).toEqual(975n);
     expect(route.terminalMinimum).toEqual(965n);
+  });
+
+  test("getHookAwareCashOutQuote routes to amm only for the chain's buyback hook", async () => {
+    const buybackHook = v6Address("JBBuybackHook", chainId);
+    const clientFor = (specHook: string) =>
+      ({
+        readContract: async (call: { functionName: string }) => {
+          if (call.functionName === "previewCashOutFrom") {
+            return [
+              {},
+              1_000n,
+              1n,
+              [
+                {
+                  hook: specHook,
+                  noop: false,
+                  amount: 0n,
+                  metadata: specMetadata(),
+                },
+              ],
+            ];
+          }
+          throw new Error(`unexpected call ${call.functionName}`);
+        },
+      }) as unknown as PublicClient;
+
+    // The chain's canonical buyback hook wins the pool route.
+    const ammRoute = await getHookAwareCashOutQuote(clientFor(buybackHook), {
+      chainId,
+      projectId,
+      holder,
+      cashOutCount: ONE_ETHER,
+      tokenToReclaim: NATIVE_TOKEN,
+    });
+    expect(ammRoute.route).toEqual("amm");
+    expect(ammRoute.terminalMinimum).toEqual(0n);
+    expect(ammRoute.buyback?.hook).toEqual(buybackHook);
+
+    // Any other hook's spec stays on the treasury path with a real minimum.
+    const treasuryRoute = await getHookAwareCashOutQuote(
+      clientFor("0x9999999999999999999999999999999999999999"),
+      {
+        chainId,
+        projectId,
+        holder,
+        cashOutCount: ONE_ETHER,
+        tokenToReclaim: NATIVE_TOKEN,
+      },
+    );
+    expect(treasuryRoute.route).toEqual("treasury");
+    expect(treasuryRoute.terminalMinimum).toEqual(965n);
+    expect(treasuryRoute.metadata).toEqual("0x");
+    expect(treasuryRoute.buyback).toBeNull();
   });
 });

--- a/packages/core/src/v6/cashOut.ts
+++ b/packages/core/src/v6/cashOut.ts
@@ -411,6 +411,13 @@ export interface CashOutRoute {
  * @param args.reclaimAmount `previewCashOutFrom`'s gross reclaim amount.
  * @param args.cashOutTaxRate `previewCashOutFrom`'s cash-out tax rate.
  * @param args.hookSpecifications `previewCashOutFrom`'s hook specifications.
+ * @param args.buybackHookAddress The chain's `JBBuybackHook` address. Only a
+ * specification from this exact hook is interpreted as the buyback route —
+ * other data hooks (e.g. a 721 tiers hook) also emit specifications with
+ * metadata, and decoding one as a buyback quote would submit a cash out with
+ * a zero terminal minimum. When omitted, every specification is treated as
+ * non-buyback and the deterministic treasury route (with its real
+ * `minTokensReclaimed` floor) is returned.
  * @param args.beneficiaryIsFeeless Whether the beneficiary is feeless.
  * Defaults to false (conservative: assumes the fee applies).
  * @param args.feeFreeSurplus The terminal's `feeFreeSurplusOf` for the token.
@@ -423,6 +430,7 @@ export function resolveCashOutRoute({
   reclaimAmount,
   cashOutTaxRate,
   hookSpecifications,
+  buybackHookAddress,
   beneficiaryIsFeeless = false,
   feeFreeSurplus = 0n,
   slippageBps = DEFAULT_CASH_OUT_SLIPPAGE_BPS,
@@ -430,6 +438,7 @@ export function resolveCashOutRoute({
   reclaimAmount: bigint;
   cashOutTaxRate: bigint;
   hookSpecifications: readonly CashOutHookSpecification[];
+  buybackHookAddress?: Address;
   beneficiaryIsFeeless?: boolean;
   feeFreeSurplus?: bigint;
   slippageBps?: bigint;
@@ -443,8 +452,14 @@ export function resolveCashOutRoute({
   });
   const treasuryNet = reclaimAmount - treasuryProtocolFee;
 
+  const buybackHook = buybackHookAddress?.toLowerCase() ?? null;
   const specification =
-    hookSpecifications.find((spec) => spec.metadata !== "0x") ?? null;
+    (buybackHook &&
+      hookSpecifications.find(
+        (spec) =>
+          spec.hook.toLowerCase() === buybackHook && spec.metadata !== "0x",
+      )) ||
+    null;
   const buyback = specification
     ? {
         hook: specification.hook,
@@ -519,6 +534,11 @@ export function resolveCashOutRoute({
  * @param args.beneficiary The reclaim beneficiary. Defaults to the holder.
  * @param args.terminal The terminal to quote against. Defaults to the chain's
  * canonical `JBMultiTerminal`.
+ * @param args.buybackHookAddress The buyback hook whose specification may win
+ * the pool route. Defaults to the chain's canonical `JBBuybackHook`; pass it
+ * explicitly for a project whose `JBBuybackHookRegistry` entry points at a
+ * custom hook. On a chain with no `JBBuybackHook` deployment, specifications
+ * are treated as non-buyback and the treasury route is returned.
  * @param args.beneficiaryIsFeeless Whether the beneficiary is feeless.
  * Defaults to false.
  * @param args.slippageBps Tolerance for quote-to-inclusion drift. Defaults to
@@ -535,6 +555,7 @@ export async function getHookAwareCashOutQuote(
     tokenToReclaim,
     beneficiary,
     terminal,
+    buybackHookAddress,
     beneficiaryIsFeeless = false,
     slippageBps = DEFAULT_CASH_OUT_SLIPPAGE_BPS,
   }: {
@@ -545,11 +566,14 @@ export async function getHookAwareCashOutQuote(
     tokenToReclaim: Address;
     beneficiary?: Address;
     terminal?: Address;
+    buybackHookAddress?: Address;
     beneficiaryIsFeeless?: boolean;
     slippageBps?: bigint;
   },
 ): Promise<CashOutRoute> {
   const terminalAddress = terminal ?? v6Address("JBMultiTerminal", chainId);
+  const buybackHook =
+    buybackHookAddress ?? optionalV6Address("JBBuybackHook", chainId);
   const [, reclaimAmount, cashOutTaxRate, hookSpecifications] =
     await client.readContract({
       address: terminalAddress,
@@ -580,8 +604,24 @@ export async function getHookAwareCashOutQuote(
     reclaimAmount,
     cashOutTaxRate,
     hookSpecifications,
+    buybackHookAddress: buybackHook,
     beneficiaryIsFeeless,
     feeFreeSurplus,
     slippageBps,
   });
+}
+
+/**
+ * `v6Address`, but returning undefined instead of throwing on a chain the
+ * contract isn't deployed to.
+ */
+function optionalV6Address(
+  contract: Parameters<typeof v6Address>[0],
+  chainId: JBChainId,
+): Address | undefined {
+  try {
+    return v6Address(contract, chainId);
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Problem

`resolveCashOutRoute` identified "the buyback spec" as the first hook specification with `metadata !== "0x"`. Any data hook returning a non-noop spec with metadata (e.g. a 721 tiers hook) could be garbage-decoded as a buyback quote and routed as an AMM sell — with `terminalMinimum = 0` and a floor keyed to the wrong hook.

## Fix

- `resolveCashOutRoute` gains an optional `buybackHookAddress` and selects the buyback spec by `spec.hook` address match (case-insensitive) + non-empty metadata.
- `getHookAwareCashOutQuote` resolves the address internally from `chainId` via the v6 address book (new internal `optionalV6Address` — chains without a JBBuybackHook deployment, e.g. OP Sepolia, now safely quote the treasury route instead of throwing).
- Fail-safe: no address known → every spec treated as non-buyback → treasury route with the real `minTokensReclaimed` floor, never a zero-minimum guess.

## Consumer impact

Patch release; callers of `getHookAwareCashOutQuote` need only the version bump. Direct `resolveCashOutRoute` callers must pass `buybackHookAddress` to keep AMM routing (omitting it yields the safe treasury route).

## Tests

5 new tests (4 confirmed failing pre-fix): non-buyback spec with decodable metadata → treasury with real minimum; no-address fail-safe; case-insensitive address match; mixed-spec selection by address; end-to-end quote with canonical vs foreign hook. Full suites green: core 285, react 126; type-check + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)