### PR TITLE
Add shared time-series downsampling

### DIFF
--- a/.changeset/fair-plums-draw.md
+++ b/.changeset/fair-plums-draw.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-core": minor
+---
+
+Add a framework-agnostic Largest-Triangle-Three-Buckets time-series downsampler for complete chart histories.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ import {
   parseTokenAmount,
   ReservedPercent,
   CashOutTaxRate,
+  downsampleTimeSeries,
 } from "@bananapus/nana-sdk-core";
 
 // Format token amounts for display
@@ -78,6 +79,14 @@ const formatted = formatTokenAmount(1000000000000000000n); // "1.0"
 // Work with project economics
 const reservedRate = new ReservedPercent(10); // 10% reserved tokens
 const taxRate = new CashOutTaxRate(2.5); // 2.5% cash out tax
+
+// Fetch complete history first, then retain its visual shape within a chart budget
+const chartPoints = downsampleTimeSeries(
+  completeHistory,
+  3000,
+  (point) => point.timestamp,
+  (point) => point.price,
+);
 ```
 
 ## Packages
@@ -143,6 +152,7 @@ const percentage = reserved.formatAsPercent(); // "15%"
 - [Data utilities](./packages/core/src/utils/data.ts) - Fixed-point data types and formatters
 - [Contract utilities](./packages/core/src/utils/contracts.ts) - Address resolution and contract helpers
 - [IPFS utilities](./packages/core/src/utils/ipfs.ts) - Metadata upload and retrieval
+- [Time-series utilities](./packages/core/src/utils/timeSeries.ts) - Shape-preserving chart downsampling
 
 ### React Hooks
 

--- a/packages/core/src/publicSurface.test.ts
+++ b/packages/core/src/publicSurface.test.ts
@@ -6,6 +6,7 @@ describe("published core SDK surfaces", () => {
   test("exports the framework-free utility and V6 transaction boundaries", () => {
     expect(sdk.getTokenAToBQuote).toBeTypeOf("function");
     expect(sdk.getProjectTerminalStore).toBeTypeOf("function");
+    expect(sdk.downsampleTimeSeries).toBeTypeOf("function");
     expect(v6.buildDeployRevnetTx).toBeTypeOf("function");
     expect(v6.buildAutoIssueTx).toBeTypeOf("function");
   });

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from "./hook.js";
 export * from "./ipfs.js";
 export * from "./revnet.js";
 export * from "./ruleset.js";
+export * from "./timeSeries.js";
 export * from "./token.js";
 export * from "./tx.js";
 export * from "./urn.js";

--- a/packages/core/src/utils/timeSeries.test.ts
+++ b/packages/core/src/utils/timeSeries.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest";
+import { downsampleTimeSeries } from "./timeSeries.js";
+
+type Point = { timestamp: number; value: number };
+
+const sample = (rows: readonly Point[], maxPoints: number) =>
+  downsampleTimeSeries(
+    rows,
+    maxPoints,
+    (point) => point.timestamp,
+    (point) => point.value,
+  );
+
+describe("downsampleTimeSeries", () => {
+  test("returns a shallow copy when the series already fits", () => {
+    const rows = [
+      { timestamp: 1, value: 1 },
+      { timestamp: 2, value: 2 },
+    ];
+
+    const result = sample(rows, 3);
+
+    expect(result).toEqual(rows);
+    expect(result).not.toBe(rows);
+  });
+
+  test("retains the first, latest, and visually significant observations", () => {
+    const rows = Array.from({ length: 100 }, (_, timestamp) => ({
+      timestamp,
+      value: timestamp === 47 ? 1_000 : timestamp % 5,
+    }));
+
+    const result = sample(rows, 12);
+
+    expect(result).toHaveLength(12);
+    expect(result[0]).toBe(rows[0]);
+    expect(result[result.length - 1]).toBe(rows[rows.length - 1]);
+    expect(result).toContain(rows[47]);
+    expect(result.map((point) => point.timestamp)).toEqual(
+      [...result].map((point) => point.timestamp).sort((a, b) => a - b),
+    );
+  });
+
+  test("does not mutate the source series", () => {
+    const rows = Object.freeze(
+      Array.from({ length: 20 }, (_, timestamp) =>
+        Object.freeze({ timestamp, value: Math.sin(timestamp) }),
+      ),
+    );
+
+    expect(() => sample(rows, 6)).not.toThrow();
+    expect(rows).toHaveLength(20);
+  });
+
+  test("has deterministic zero, one, and two-point limits", () => {
+    const rows = [
+      { timestamp: 1, value: 10 },
+      { timestamp: 2, value: 20 },
+      { timestamp: 3, value: 30 },
+    ];
+
+    expect(sample(rows, 0)).toEqual([]);
+    expect(sample(rows, 1)).toEqual([rows[0]]);
+    expect(sample(rows, 2)).toEqual([rows[0], rows[2]]);
+  });
+
+  test("rejects invalid point limits", () => {
+    const rows = [{ timestamp: 1, value: 10 }];
+
+    expect(() => sample(rows, -1)).toThrow(RangeError);
+    expect(() => sample(rows, 1.5)).toThrow(RangeError);
+    expect(() => sample(rows, Number.POSITIVE_INFINITY)).toThrow(RangeError);
+  });
+
+  test("handles non-finite projected coordinates deterministically", () => {
+    const rows = Array.from({ length: 10 }, (_, timestamp) => ({
+      timestamp,
+      value: timestamp === 4 ? Number.NaN : timestamp,
+    }));
+
+    const first = sample(rows, 5);
+    const second = sample(rows, 5);
+
+    expect(first).toEqual(second);
+    expect(first).toHaveLength(5);
+    expect(first[0]).toBe(rows[0]);
+    expect(first[first.length - 1]).toBe(rows[rows.length - 1]);
+  });
+});

--- a/packages/core/src/utils/timeSeries.ts
+++ b/packages/core/src/utils/timeSeries.ts
@@ -1,0 +1,82 @@
+/**
+ * Downsample an ordered time series with the Largest-Triangle-Three-Buckets
+ * algorithm.
+ *
+ * The returned series never mutates `rows`, retains both endpoints whenever
+ * `maxPoints` is at least two, and preserves visually significant intermediate
+ * points better than fixed-interval sampling. Callers should pass rows in
+ * ascending X order.
+ *
+ * Non-finite projected coordinates are treated as zero so malformed source
+ * observations cannot make every triangle area `NaN`.
+ */
+export function downsampleTimeSeries<T>(
+  rows: readonly T[],
+  maxPoints: number,
+  xOf: (row: T) => number,
+  yOf: (row: T) => number,
+): T[] {
+  if (!Number.isSafeInteger(maxPoints) || maxPoints < 0) {
+    throw new RangeError("maxPoints must be a non-negative safe integer");
+  }
+  if (maxPoints === 0 || rows.length === 0) return [];
+  if (rows.length <= maxPoints) return rows.slice();
+  if (maxPoints < 3) {
+    return [rows[0]!, rows[rows.length - 1]!].slice(0, maxPoints);
+  }
+
+  const x = rows.map((row) => finite(xOf(row)));
+  const y = rows.map((row) => finite(yOf(row)));
+  const sampled: T[] = [rows[0]!];
+  const bucketWidth = (rows.length - 2) / (maxPoints - 2);
+  let anchorIndex = 0;
+
+  for (let bucketIndex = 0; bucketIndex < maxPoints - 2; bucketIndex += 1) {
+    const averageStart = Math.floor((bucketIndex + 1) * bucketWidth) + 1;
+    const averageEnd = Math.min(
+      Math.floor((bucketIndex + 2) * bucketWidth) + 1,
+      rows.length,
+    );
+    const averageLength = averageEnd - averageStart;
+    let averageX = 0;
+    let averageY = 0;
+
+    for (let index = averageStart; index < averageEnd; index += 1) {
+      averageX += x[index]!;
+      averageY += y[index]!;
+    }
+    averageX /= averageLength;
+    averageY /= averageLength;
+
+    const rangeStart = Math.floor(bucketIndex * bucketWidth) + 1;
+    const rangeEnd = Math.min(
+      Math.floor((bucketIndex + 1) * bucketWidth) + 1,
+      rows.length - 1,
+    );
+    const anchorX = x[anchorIndex]!;
+    const anchorY = y[anchorIndex]!;
+    let largestArea = -1;
+    let selectedIndex = rangeStart;
+
+    for (let index = rangeStart; index < rangeEnd; index += 1) {
+      const area = Math.abs(
+        (anchorX - averageX) * (y[index]! - anchorY) -
+          (anchorX - x[index]!) * (averageY - anchorY),
+      );
+      if (area > largestArea) {
+        largestArea = area;
+        selectedIndex = index;
+      }
+    }
+
+    sampled.push(rows[selectedIndex]!);
+    anchorIndex = selectedIndex;
+  }
+
+  sampled.push(rows[rows.length - 1]!);
+  return sampled;
+}
+
+function finite(value: number): number {
+  return Number.isFinite(value) ? value : 0;
+}


### PR DESCRIPTION
## What changed

- Add a framework-agnostic `downsampleTimeSeries` utility to `@bananapus/nana-sdk-core`.
- Use Largest-Triangle-Three-Buckets sampling with stable ordering, immutable input handling, endpoint retention, and deterministic non-finite-coordinate handling.
- Export the utility from the package root and lock the public surface with a test.
- Document the complete-history-then-downsample usage pattern.
- Add a minor changeset so the core package is versioned and published after merge.

## Why

Juicebox Money, Juicy Vision, and Revnet Money currently need the same shape-preserving chart behavior. A canonical SDK implementation removes three nearly identical local utilities and gives future web clients a tested path that does not depend on React, a charting library, or a specific data source.

The utility intentionally does not fetch data: clients and indexers derive price history from different sources. They should retrieve a complete, correctly ordered series and then apply this sampler to the final plotted metric.

## Validation

- Full `npm run check` release gate
- 35 core test files / 291 tests passed
- 36 React test files / 126 tests passed
- 100% statement, branch, function, and line coverage for `timeSeries.ts`
- Core ESM and CJS builds passed
- Workspace typechecks, protocol checks, wallet-boundary checks, GraphQL generation, package budgets, and generated-file checks passed