### PR TITLE
Align Bendystraw reads across SDK consumers

### DIFF
--- a/.changeset/calm-straws-align.md
+++ b/.changeset/calm-straws-align.md
@@ -1,0 +1,8 @@
+---
+"@bananapus/nana-sdk-core": minor
+"@bananapus/nana-sdk-react": patch
+---
+
+Add bounded Bendystraw requests, exact versioned project-reference filters,
+and 200-reference query batching, and use the shared transport in the React
+Bendystraw hook.

--- a/packages/core/src/publicSurface.test.ts
+++ b/packages/core/src/publicSurface.test.ts
@@ -7,6 +7,9 @@ describe("published core SDK surfaces", () => {
     expect(sdk.getTokenAToBQuote).toBeTypeOf("function");
     expect(sdk.getProjectTerminalStore).toBeTypeOf("function");
     expect(sdk.downsampleTimeSeries).toBeTypeOf("function");
+    expect(sdk.requestBendystraw).toBeTypeOf("function");
+    expect(sdk.bendystrawProjectRefsFilter).toBeTypeOf("function");
+    expect(sdk.bendystrawProjectRefsFilters).toBeTypeOf("function");
     expect(v6.buildDeployRevnetTx).toBeTypeOf("function");
     expect(v6.buildAutoIssueTx).toBeTypeOf("function");
   });

--- a/packages/core/src/utils/bendystraw.test.ts
+++ b/packages/core/src/utils/bendystraw.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  BendystrawRequestError,
+  bendystrawProjectRefFilter,
+  bendystrawProjectRefsFilter,
+  bendystrawProjectRefsFilters,
+  matchesBendystrawProjectRef,
+  requestBendystraw,
+} from "./bendystraw.js";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
+describe("Bendystraw project reference filters", () => {
+  test("builds explicit versioned conjunctions", () => {
+    expect(bendystrawProjectRefFilter({ chainId: 1, projectId: 7 })).toEqual({
+      AND: [{ chainId: 1 }, { projectId: 7 }, { version: 6 }],
+    });
+    expect(
+      bendystrawProjectRefFilter({ chainId: 8453, projectId: 9, version: 5 }),
+    ).toEqual({
+      AND: [{ chainId: 8453 }, { projectId: 9 }, { version: 5 }],
+    });
+  });
+
+  test("deduplicates refs and uses OR only for distinct deployments", () => {
+    expect(
+      bendystrawProjectRefsFilter([
+        { chainId: 1, projectId: 7 },
+        { chainId: 1, projectId: 7, version: 6 },
+      ]),
+    ).toEqual({
+      AND: [{ chainId: 1 }, { projectId: 7 }, { version: 6 }],
+    });
+    expect(
+      bendystrawProjectRefsFilter([
+        { chainId: 1, projectId: 7 },
+        { chainId: 8453, projectId: 11 },
+      ]),
+    ).toEqual({
+      OR: [
+        { AND: [{ chainId: 1 }, { projectId: 7 }, { version: 6 }] },
+        {
+          AND: [{ chainId: 8453 }, { projectId: 11 }, { version: 6 }],
+        },
+      ],
+    });
+  });
+
+  test("rejects empty and malformed refs instead of broadening a query", () => {
+    expect(() => bendystrawProjectRefsFilter([])).toThrow(TypeError);
+    for (const ref of [
+      { chainId: 0, projectId: 1 },
+      { chainId: 1.5, projectId: 1 },
+      { chainId: 1, projectId: 0 },
+      { chainId: 1, projectId: -1 },
+      { chainId: 1, projectId: Number.MAX_SAFE_INTEGER + 1 },
+      { chainId: 1, projectId: 1, version: 0 },
+    ]) {
+      expect(() => bendystrawProjectRefFilter(ref)).toThrow(
+        "Invalid Bendystraw project reference",
+      );
+    }
+  });
+
+  test("builds bounded, independently queryable exact-ref batches", () => {
+    expect(
+      bendystrawProjectRefsFilters(
+        [
+          { chainId: 1, projectId: 7 },
+          { chainId: 1, projectId: 7, version: 6 },
+          { chainId: 8453, projectId: 11 },
+        ],
+        1,
+      ),
+    ).toEqual([
+      { OR: [{ AND: [{ chainId: 1 }, { projectId: 7 }, { version: 6 }] }] },
+      {
+        OR: [
+          {
+            AND: [{ chainId: 8453 }, { projectId: 11 }, { version: 6 }],
+          },
+        ],
+      },
+    ]);
+    expect(bendystrawProjectRefsFilters([])).toEqual([]);
+    expect(() =>
+      bendystrawProjectRefsFilters([{ chainId: 1, projectId: 7 }], 0),
+    ).toThrow("batchSize");
+  });
+
+  test("matches only exact, well-formed deployment rows", () => {
+    const refs = [
+      { chainId: 1, projectId: 7 },
+      { chainId: 8453, projectId: 11, version: 5 },
+    ];
+    expect(
+      matchesBendystrawProjectRef(
+        { chainId: "8453", projectId: "11", version: "5" },
+        refs,
+      ),
+    ).toBe(true);
+    expect(
+      matchesBendystrawProjectRef(
+        { chainId: 8453, projectId: 7, version: 6 },
+        refs,
+      ),
+    ).toBe(false);
+    expect(
+      matchesBendystrawProjectRef(
+        { chainId: "bad", projectId: 7, version: 6 },
+        refs,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("requestBendystraw", () => {
+  test("posts the exact GraphQL envelope and returns data", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ data: { project: { id: "1" } } }));
+
+    await expect(
+      requestBendystraw<{ project: { id: string } }, { projectId: number }>(
+        "https://bendystraw.example/graphql",
+        "query Project($projectId: Int!) { project(projectId: $projectId) { id } }",
+        { projectId: 1 },
+        { fetch: fetchMock },
+      ),
+    ).resolves.toEqual({ project: { id: "1" } });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [endpoint, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(endpoint).toBe("https://bendystraw.example/graphql");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      Accept: "application/graphql-response+json, application/json",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(init.body))).toEqual({
+      query:
+        "query Project($projectId: Int!) { project(projectId: $projectId) { id } }",
+      variables: { projectId: 1 },
+    });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("retries transient HTTP and network failures with a bounded schedule", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, { status: 503 }))
+      .mockRejectedValueOnce(new TypeError("network down"))
+      .mockResolvedValueOnce(jsonResponse({ data: { ok: true } }));
+
+    await expect(
+      requestBendystraw<{ ok: boolean }>(
+        "https://bendystraw.example/graphql",
+        "query { ok }",
+        {},
+        { fetch: fetchMock, retryDelaysMs: [0, 0] },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  test("does not retry terminal HTTP, GraphQL, or envelope failures", async () => {
+    const cases: Array<[Response, string]> = [
+      [jsonResponse({}, { status: 400 }), "request failed (400)"],
+      [jsonResponse({ errors: [{ message: "nope" }] }), "nope"],
+      [jsonResponse({}), "missing data"],
+      [
+        new Response("<html>", {
+          headers: { "content-type": "text/html" },
+        }),
+        "invalid content type",
+      ],
+      [
+        new Response("{", {
+          headers: { "content-type": "application/json" },
+        }),
+        "invalid JSON",
+      ],
+    ];
+
+    for (const [response, message] of cases) {
+      const fetchMock = vi.fn().mockResolvedValue(response);
+      await expect(
+        requestBendystraw(
+          "https://bendystraw.example/graphql",
+          "query { ok }",
+          {},
+          { fetch: fetchMock, retryDelaysMs: [0, 0] },
+        ),
+      ).rejects.toThrow(message);
+      expect(fetchMock).toHaveBeenCalledOnce();
+    }
+  });
+
+  test("rejects declared and streamed bodies over the configured limit", async () => {
+    const declared = jsonResponse(
+      { data: { ok: true } },
+      { headers: { "content-length": "100" } },
+    );
+    await expect(
+      requestBendystraw(
+        "https://bendystraw.example/graphql",
+        "query { ok }",
+        {},
+        { fetch: vi.fn().mockResolvedValue(declared), maxResponseBytes: 10 },
+      ),
+    ).rejects.toBeInstanceOf(BendystrawRequestError);
+
+    const streamed = jsonResponse({ data: { value: "too large" } });
+    await expect(
+      requestBendystraw(
+        "https://bendystraw.example/graphql",
+        "query { value }",
+        {},
+        { fetch: vi.fn().mockResolvedValue(streamed), maxResponseBytes: 10 },
+      ),
+    ).rejects.toThrow("size limit");
+  });
+
+  test("honors caller cancellation and validates resource bounds", async () => {
+    const aborted = new AbortController();
+    aborted.abort();
+    const fetchMock = vi.fn().mockImplementation(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          if (init?.signal?.aborted) {
+            reject(new DOMException("Aborted", "AbortError"));
+            return;
+          }
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+    await expect(
+      requestBendystraw(
+        "https://bendystraw.example/graphql",
+        "query { ok }",
+        {},
+        { fetch: fetchMock, signal: aborted.signal },
+      ),
+    ).rejects.toHaveProperty("name", "AbortError");
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    await expect(
+      requestBendystraw(
+        "https://bendystraw.example/graphql",
+        "query { ok }",
+        {},
+        { maxResponseBytes: 0 },
+      ),
+    ).rejects.toThrow("maxResponseBytes");
+    await expect(
+      requestBendystraw(
+        "https://bendystraw.example/graphql",
+        "query { ok }",
+        {},
+        { timeoutMs: 0 },
+      ),
+    ).rejects.toThrow("timeoutMs");
+  });
+});

--- a/packages/core/src/utils/bendystraw.ts
+++ b/packages/core/src/utils/bendystraw.ts
@@ -1,0 +1,331 @@
+export const BENDYSTRAW_TIMEOUT_MS = 15_000;
+export const MAX_BENDYSTRAW_RESPONSE_BYTES = 5 * 1024 * 1024;
+export const BENDYSTRAW_PROJECT_REF_BATCH_SIZE = 200;
+
+const RETRY_DELAYS_MS = [250, 750] as const;
+const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+
+export type BendystrawFilter = Record<string, unknown>;
+
+export type BendystrawProjectRef = {
+  chainId: number;
+  projectId: number;
+  version?: number;
+};
+
+export type BendystrawProjectRow = {
+  chainId?: unknown;
+  projectId?: unknown;
+  version?: unknown;
+};
+
+export class BendystrawRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "BendystrawRequestError";
+  }
+}
+
+export type BendystrawRequestOptions = {
+  fetch?: typeof fetch;
+  maxResponseBytes?: number;
+  retryDelaysMs?: readonly number[];
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+function normalizeProjectRef(
+  ref: BendystrawProjectRef,
+): Required<BendystrawProjectRef> {
+  const version = ref.version ?? 6;
+  if (
+    !Number.isSafeInteger(ref.chainId) ||
+    ref.chainId <= 0 ||
+    !Number.isSafeInteger(ref.projectId) ||
+    ref.projectId <= 0 ||
+    !Number.isSafeInteger(version) ||
+    version <= 0
+  ) {
+    throw new TypeError("Invalid Bendystraw project reference");
+  }
+  return { chainId: ref.chainId, projectId: ref.projectId, version };
+}
+
+/**
+ * Build an explicit conjunction for one versioned deployment. Keeping each
+ * identity field in its own `AND` member prevents accidental project/chain
+ * cross-products when multiple deployments are combined with `OR`.
+ */
+export function bendystrawProjectRefFilter(
+  ref: BendystrawProjectRef,
+): BendystrawFilter {
+  const normalized = normalizeProjectRef(ref);
+  return {
+    AND: [
+      { chainId: normalized.chainId },
+      { projectId: normalized.projectId },
+      { version: normalized.version },
+    ],
+  };
+}
+
+/**
+ * Build an exact filter for one or more deployments. An empty list throws
+ * instead of silently producing a broad, unscoped indexer query.
+ */
+export function bendystrawProjectRefsFilter(
+  refs: readonly BendystrawProjectRef[],
+): BendystrawFilter {
+  const unique = new Map<string, Required<BendystrawProjectRef>>();
+  for (const ref of refs) {
+    const normalized = normalizeProjectRef(ref);
+    unique.set(
+      `${normalized.chainId}:${normalized.projectId}:${normalized.version}`,
+      normalized,
+    );
+  }
+  const filters = [...unique.values()].map(bendystrawProjectRefFilter);
+  if (filters.length === 0) {
+    throw new TypeError(
+      "At least one Bendystraw project reference is required",
+    );
+  }
+  return filters.length === 1 ? filters[0] : { OR: filters };
+}
+
+/**
+ * Build independently queryable exact-deployment filters without handing an
+ * indexer one unbounded `OR`. Empty input produces no queries; malformed refs
+ * still fail closed.
+ */
+export function bendystrawProjectRefsFilters(
+  refs: readonly BendystrawProjectRef[],
+  batchSize = BENDYSTRAW_PROJECT_REF_BATCH_SIZE,
+): BendystrawFilter[] {
+  if (!Number.isSafeInteger(batchSize) || batchSize <= 0) {
+    throw new TypeError("batchSize must be a positive safe integer");
+  }
+
+  const unique = new Map<string, Required<BendystrawProjectRef>>();
+  for (const ref of refs) {
+    const normalized = normalizeProjectRef(ref);
+    unique.set(
+      `${normalized.chainId}:${normalized.projectId}:${normalized.version}`,
+      normalized,
+    );
+  }
+
+  const normalized = [...unique.values()];
+  const batches: BendystrawFilter[] = [];
+  for (let index = 0; index < normalized.length; index += batchSize) {
+    batches.push({
+      OR: normalized
+        .slice(index, index + batchSize)
+        .map(bendystrawProjectRefFilter),
+    });
+  }
+  return batches;
+}
+
+/**
+ * Verify that an indexer row belongs to one of the requested deployments.
+ * Use this at the response boundary as defense in depth against stale schemas,
+ * permissive filters, and indexer regressions.
+ */
+export function matchesBendystrawProjectRef(
+  row: BendystrawProjectRow,
+  refs: readonly BendystrawProjectRef[],
+): boolean {
+  const chainId = Number(row.chainId);
+  const projectId = Number(row.projectId);
+  const version = Number(row.version);
+  if (
+    !Number.isSafeInteger(chainId) ||
+    !Number.isSafeInteger(projectId) ||
+    !Number.isSafeInteger(version)
+  ) {
+    return false;
+  }
+  return refs.some((ref) => {
+    const normalized = normalizeProjectRef(ref);
+    return (
+      chainId === normalized.chainId &&
+      projectId === normalized.projectId &&
+      version === normalized.version
+    );
+  });
+}
+
+async function readBoundedBody(
+  response: Response,
+  maxResponseBytes: number,
+): Promise<Uint8Array> {
+  const declaredSize = Number(response.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declaredSize) && declaredSize > maxResponseBytes) {
+    await response.body?.cancel();
+    throw new BendystrawRequestError(
+      "Bendystraw response exceeds the size limit",
+      502,
+    );
+  }
+  if (!response.headers.get("content-type")?.toLowerCase().includes("json")) {
+    await response.body?.cancel();
+    throw new BendystrawRequestError(
+      "Bendystraw returned an invalid content type",
+      502,
+    );
+  }
+  if (!response.body) return new Uint8Array();
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxResponseBytes) {
+        await reader.cancel("Bendystraw response exceeds the size limit");
+        throw new BendystrawRequestError(
+          "Bendystraw response exceeds the size limit",
+          502,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+function abortName(error: unknown): string | undefined {
+  return error instanceof Error ? error.name : undefined;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+/**
+ * Execute a bounded, timeout-protected Bendystraw GraphQL request.
+ *
+ * The helper retries only transient transport failures. GraphQL errors,
+ * invalid envelopes, invalid content types, oversized bodies, and caller
+ * cancellation fail closed without being retried.
+ */
+export async function requestBendystraw<
+  TResult,
+  TVariables extends object = Record<string, never>,
+>(
+  endpoint: string,
+  query: string,
+  variables: TVariables,
+  options: BendystrawRequestOptions = {},
+): Promise<TResult> {
+  const fetchImpl = options.fetch ?? fetch;
+  const maxResponseBytes =
+    options.maxResponseBytes ?? MAX_BENDYSTRAW_RESPONSE_BYTES;
+  const retryDelaysMs = options.retryDelaysMs ?? RETRY_DELAYS_MS;
+  const timeoutMs = options.timeoutMs ?? BENDYSTRAW_TIMEOUT_MS;
+
+  if (!Number.isSafeInteger(maxResponseBytes) || maxResponseBytes <= 0) {
+    throw new TypeError("maxResponseBytes must be a positive safe integer");
+  }
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError("timeoutMs must be positive");
+  }
+
+  for (let attempt = 0; ; attempt += 1) {
+    const controller = new AbortController();
+    const abort = () => controller.abort(options.signal?.reason);
+    options.signal?.addEventListener("abort", abort, { once: true });
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      if (options.signal?.aborted) abort();
+      const response = await fetchImpl(endpoint, {
+        method: "POST",
+        headers: {
+          Accept: "application/graphql-response+json, application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query, variables }),
+        signal: controller.signal,
+      });
+
+      if (
+        RETRYABLE_STATUSES.has(response.status) &&
+        attempt < retryDelaysMs.length
+      ) {
+        await response.body?.cancel();
+      } else {
+        const bytes = await readBoundedBody(response, maxResponseBytes);
+        let envelope: {
+          data?: TResult;
+          errors?: Array<{ message?: unknown }>;
+        };
+        try {
+          envelope = JSON.parse(
+            new TextDecoder().decode(bytes),
+          ) as typeof envelope;
+        } catch {
+          throw new BendystrawRequestError(
+            "Bendystraw returned invalid JSON",
+            502,
+          );
+        }
+        if (!response.ok) {
+          throw new BendystrawRequestError(
+            `Bendystraw request failed (${response.status})`,
+            response.status,
+          );
+        }
+        const message = envelope.errors?.find(
+          (error) => typeof error?.message === "string",
+        )?.message;
+        if (envelope.errors?.length) {
+          throw new BendystrawRequestError(
+            typeof message === "string"
+              ? message.slice(0, 500)
+              : "Bendystraw query failed",
+            502,
+          );
+        }
+        if (!Object.prototype.hasOwnProperty.call(envelope, "data")) {
+          throw new BendystrawRequestError(
+            "Bendystraw response is missing data",
+            502,
+          );
+        }
+        return envelope.data as TResult;
+      }
+    } catch (error) {
+      const aborted =
+        options.signal?.aborted ||
+        abortName(error) === "AbortError" ||
+        abortName(error) === "TimeoutError";
+      if (
+        aborted ||
+        error instanceof BendystrawRequestError ||
+        attempt >= retryDelaysMs.length
+      ) {
+        throw error;
+      }
+    } finally {
+      clearTimeout(timeout);
+      options.signal?.removeEventListener("abort", abort);
+    }
+    await delay(retryDelaysMs[attempt]);
+  }
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./contracts.js";
+export * from "./bendystraw.js";
 export * from "./data.js";
 export * from "./debug.js";
 export * from "./deploy.js";

--- a/packages/react/src/lib/bendystraw/useBendystrawQuery.test.ts
+++ b/packages/react/src/lib/bendystraw/useBendystrawQuery.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   chainId: 1 as number | undefined,
   config: { apiKey: "secret" } as { apiKey: string; url?: string } | undefined,
   queryConfig: undefined as any,
-  request: vi.fn(),
+  requestBendystraw: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -16,7 +16,16 @@ vi.mock("@tanstack/react-query", () => ({
   },
 }));
 
-vi.mock("graphql-request", () => ({ default: mocks.request }));
+vi.mock("@bananapus/nana-sdk-core", () => ({
+  requestBendystraw: mocks.requestBendystraw,
+}));
+
+vi.mock("graphql-request", () => ({
+  analyzeDocument: () => ({
+    expression: "query Project($projectId: Int!) { project { id } }",
+    operationName: "Project",
+  }),
+}));
 
 vi.mock("../../contexts/JBChainContext/JBChainContext", () => ({
   useJBChainId: () => mocks.chainId,
@@ -38,7 +47,7 @@ describe("useBendystrawQuery", () => {
     vi.clearAllMocks();
     mocks.chainId = 1;
     mocks.config = { apiKey: "secret" };
-    mocks.request.mockResolvedValue({ project: { id: "1" } });
+    mocks.requestBendystraw.mockResolvedValue({ project: { id: "1" } });
   });
 
   test("keys and requests the chain's configured Bendystraw endpoint", async () => {
@@ -56,9 +65,9 @@ describe("useBendystrawQuery", () => {
     await expect(mocks.queryConfig.queryFn()).resolves.toEqual({
       project: { id: "1" },
     });
-    expect(mocks.request).toHaveBeenCalledWith(
+    expect(mocks.requestBendystraw).toHaveBeenCalledWith(
       "https://bendystraw.xyz/secret/graphql",
-      document,
+      "query Project($projectId: Int!) { project { id } }",
       variables,
     );
   });
@@ -75,9 +84,9 @@ describe("useBendystrawQuery", () => {
       "https://bendystraw.example/indexer/tenant-a",
     );
     await mocks.queryConfig.queryFn();
-    expect(mocks.request).toHaveBeenCalledWith(
+    expect(mocks.requestBendystraw).toHaveBeenCalledWith(
       "https://bendystraw.example/indexer/tenant-a/graphql",
-      document,
+      "query Project($projectId: Int!) { project { id } }",
       { projectId: 2 },
     );
   });
@@ -88,9 +97,9 @@ describe("useBendystrawQuery", () => {
     useBendystrawQuery(document, { projectId: 3 });
 
     await mocks.queryConfig.queryFn();
-    expect(mocks.request).toHaveBeenCalledWith(
+    expect(mocks.requestBendystraw).toHaveBeenCalledWith(
       "https://testnet.bendystraw.xyz/secret/graphql",
-      document,
+      "query Project($projectId: Int!) { project { id } }",
       { projectId: 3 },
     );
   });
@@ -124,13 +133,10 @@ describe("useBendystrawQuery", () => {
     expect(mocks.queryConfig.staleTime).toBe(Infinity);
   });
 
-  test("uses bounded exponential retry and stable cache timing", () => {
+  test("delegates bounded retries to the transport and keeps stable cache timing", () => {
     useBendystrawQuery(document, { projectId: 1 });
 
-    expect(mocks.queryConfig.retry).toBe(3);
-    expect(mocks.queryConfig.retryDelay(0)).toBe(1000);
-    expect(mocks.queryConfig.retryDelay(1)).toBe(2000);
-    expect(mocks.queryConfig.retryDelay(5)).toBe(30000);
+    expect(mocks.queryConfig.retry).toBe(false);
     expect(mocks.queryConfig.staleTime).toBe(30000);
     expect(mocks.queryConfig.gcTime).toBe(300000);
   });

--- a/packages/react/src/lib/bendystraw/useBendystrawQuery.ts
+++ b/packages/react/src/lib/bendystraw/useBendystrawQuery.ts
@@ -1,8 +1,9 @@
 "use client";
 
 import { type TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { requestBendystraw } from "@bananapus/nana-sdk-core";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
-import request from "graphql-request";
+import { analyzeDocument } from "graphql-request";
 import { useJBChainId } from "../../contexts/JBChainContext/JBChainContext";
 import { getBendystrawUrl } from "./getBendystrawUrl";
 import { useBendystrawConfig } from "../../contexts/JBProjectProvider/JBProjectProvider";
@@ -32,11 +33,16 @@ export function useBendystrawQuery<TResult, TVariables>(
       variables,
     ],
     queryFn: async () =>
-      request(`${url}/graphql`, document, variables as object),
+      requestBendystraw<TResult, object>(
+        `${url}/graphql`,
+        analyzeDocument(document).expression,
+        variables as object,
+      ),
     enabled: options?.enabled !== false && !!chainId && !!url,
     refetchInterval: options?.pollInterval,
-    retry: 3,
-    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000), // Exponential backoff
+    // requestBendystraw owns bounded transient retries. Retrying again here
+    // would multiply requests and make timeout behavior inconsistent.
+    retry: false,
     staleTime: options?.staleTime ?? 30000, // Consider data stale after 30 seconds by default
     gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes
   });

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -7,9 +7,10 @@ const repositoryUrl = "https://github.com/Bananapus/juice-sdk-v4";
 const budgets = {
   "@bananapus/nana-sdk-core": {
     directory: "packages/core",
-    packed: 750_000,
+    // Includes the public Bendystraw transport in both ESM and CJS formats.
+    packed: 752_000,
     unpacked: 16_800_000,
-    entries: 350,
+    entries: 354,
   },
   "@bananapus/nana-sdk-react": {
     directory: "packages/react",


### PR DESCRIPTION
## What changed

- add a framework-free Bendystraw transport with a 15-second timeout, a 5 MiB response cap, and bounded retries for transient failures
- add exact versioned project-reference filters, response matching, deduplication, and 200-reference batching
- route the React `useBendystrawQuery` hook through the shared core transport without multiplying retries at the React Query layer
- export and test the new public core surface
- include a core minor / React patch changeset and narrowly adjust the package budget for the new ESM/CJS utility files

## Why

The four web clients had independently evolved Bendystraw request, retry, and project-identity behavior. That made valid-but-incorrect cross-project reads and inconsistent failure behavior possible. The SDK now provides one reviewed path for current and future React clients while preserving exact `{ chainId, projectId, version }` deployment identity.

## Impact

Consumers get consistent bounded network behavior and reusable helpers that prevent project/chain cross products. Existing hook callers keep the same API.

## Validation

- `npm run check`
- 301 core tests and 126 React tests
- type checks and GraphQL generation
- ESM/CJS builds
- generated-artifact checks
- package budgets (`750,963 B` core packed; `147,153 B` React packed)