### PR TITLE
Avoid viem chain barrel imports

### DIFF
--- a/.changeset/calm-chains-build.md
+++ b/.changeset/calm-chains-build.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-core": patch
+---
+
+Define supported chains without importing the full viem chain barrel, keeping browser builds deterministic and warning-free.

--- a/packages/core/src/chains.test.ts
+++ b/packages/core/src/chains.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  arbitrum as viemArbitrum,
+  arbitrumSepolia as viemArbitrumSepolia,
+  base as viemBase,
+  baseSepolia as viemBaseSepolia,
+  mainnet as viemMainnet,
+  optimism as viemOptimism,
+  optimismSepolia as viemOptimismSepolia,
+  sepolia as viemSepolia,
+} from "viem/chains";
+import {
+  arbitrum,
+  arbitrumSepolia,
+  base,
+  baseSepolia,
+  mainnet,
+  optimism,
+  optimismSepolia,
+  sepolia,
+} from "./chains.js";
+
+describe("supported chain definitions", () => {
+  it.each([
+    ["mainnet", mainnet, viemMainnet],
+    ["sepolia", sepolia, viemSepolia],
+    ["optimism", optimism, viemOptimism],
+    ["optimismSepolia", optimismSepolia, viemOptimismSepolia],
+    ["base", base, viemBase],
+    ["baseSepolia", baseSepolia, viemBaseSepolia],
+    ["arbitrum", arbitrum, viemArbitrum],
+    ["arbitrumSepolia", arbitrumSepolia, viemArbitrumSepolia],
+  ])("keeps %s aligned with viem", (_name, local, upstream) => {
+    expect(local).toEqual(upstream);
+  });
+});

--- a/packages/core/src/chains.ts
+++ b/packages/core/src/chains.ts
@@ -1,0 +1,305 @@
+import { defineChain } from "viem";
+import { chainConfig } from "viem/op-stack";
+
+/**
+ * Juicebox's supported chains.
+ *
+ * Keep these definitions local instead of importing the `viem/chains` barrel.
+ * That barrel eagerly exposes every chain, including chains with runtime-only
+ * modules which client bundlers cannot statically analyse.
+ */
+export const mainnet = defineChain({
+  id: 1,
+  name: "Ethereum",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  blockTime: 12_000,
+  rpcUrls: {
+    default: { http: ["https://eth.merkle.io"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Etherscan",
+      url: "https://etherscan.io",
+      apiUrl: "https://api.etherscan.io/api",
+    },
+  },
+  contracts: {
+    ensUniversalResolver: {
+      address: "0xeeeeeeee14d718c2b47d9923deab1335e144eeee",
+      blockCreated: 23_085_558,
+    },
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 14_353_601,
+    },
+  },
+});
+
+export const sepolia = defineChain({
+  id: 11_155_111,
+  name: "Sepolia",
+  nativeCurrency: { name: "Sepolia Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: {
+    default: { http: ["https://sepolia.drpc.org"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Etherscan",
+      url: "https://sepolia.etherscan.io",
+      apiUrl: "https://api-sepolia.etherscan.io/api",
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 751_532,
+    },
+    ensUniversalResolver: {
+      address: "0xeeeeeeee14d718c2b47d9923deab1335e144eeee",
+      blockCreated: 8_928_790,
+    },
+  },
+  testnet: true,
+});
+
+const optimismSourceId = 1;
+
+export const optimism = defineChain({
+  ...chainConfig,
+  id: 10,
+  name: "OP Mainnet",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: {
+    default: { http: ["https://mainnet.optimism.io"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Optimism Explorer",
+      url: "https://optimistic.etherscan.io",
+      apiUrl: "https://api-optimistic.etherscan.io/api",
+    },
+  },
+  contracts: {
+    ...chainConfig.contracts,
+    disputeGameFactory: {
+      [optimismSourceId]: {
+        address: "0xe5965Ab5962eDc7477C8520243A95517CD252fA9",
+      },
+    },
+    l2OutputOracle: {
+      [optimismSourceId]: {
+        address: "0xdfe97868233d1aa22e815a266982f2cf17685a27",
+      },
+    },
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 4_286_263,
+    },
+    portal: {
+      [optimismSourceId]: {
+        address: "0xbEb5Fc579115071764c7423A4f12eDde41f106Ed",
+      },
+    },
+    l1StandardBridge: {
+      [optimismSourceId]: {
+        address: "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
+      },
+    },
+  },
+  sourceId: optimismSourceId,
+});
+
+const sepoliaSourceId = 11_155_111;
+
+export const optimismSepolia = defineChain({
+  ...chainConfig,
+  id: 11_155_420,
+  name: "OP Sepolia",
+  nativeCurrency: { name: "Sepolia Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: {
+    default: { http: ["https://sepolia.optimism.io"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Blockscout",
+      url: "https://optimism-sepolia.blockscout.com",
+      apiUrl: "https://optimism-sepolia.blockscout.com/api",
+    },
+  },
+  contracts: {
+    ...chainConfig.contracts,
+    disputeGameFactory: {
+      [sepoliaSourceId]: {
+        address: "0x05F9613aDB30026FFd634f38e5C4dFd30a197Fa1",
+      },
+    },
+    l2OutputOracle: {
+      [sepoliaSourceId]: {
+        address: "0x90E9c4f8a994a250F6aEfd61CAFb4F2e895D458F",
+      },
+    },
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 1_620_204,
+    },
+    portal: {
+      [sepoliaSourceId]: {
+        address: "0x16Fc5058F25648194471939df75CF27A2fdC48BC",
+      },
+    },
+    l1StandardBridge: {
+      [sepoliaSourceId]: {
+        address: "0xFBb0621E0B23b5478B630BD55a5f21f67730B0F1",
+      },
+    },
+  },
+  testnet: true,
+  sourceId: sepoliaSourceId,
+});
+
+export const base = defineChain({
+  ...chainConfig,
+  id: 8_453,
+  name: "Base",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: {
+    default: { http: ["https://mainnet.base.org"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Basescan",
+      url: "https://basescan.org",
+      apiUrl: "https://api.basescan.org/api",
+    },
+  },
+  contracts: {
+    ...chainConfig.contracts,
+    disputeGameFactory: {
+      [optimismSourceId]: {
+        address: "0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e",
+      },
+    },
+    l2OutputOracle: {
+      [optimismSourceId]: {
+        address: "0x56315b90c40730925ec5485cf004d835058518A0",
+      },
+    },
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 5_022,
+    },
+    portal: {
+      [optimismSourceId]: {
+        address: "0x49048044D57e1C92A77f79988d21Fa8fAF74E97e",
+        blockCreated: 17_482_143,
+      },
+    },
+    l1StandardBridge: {
+      [optimismSourceId]: {
+        address: "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+        blockCreated: 17_482_143,
+      },
+    },
+  },
+  sourceId: optimismSourceId,
+});
+
+export const baseSepolia = defineChain({
+  ...chainConfig,
+  id: 84_532,
+  network: "base-sepolia",
+  name: "Base Sepolia",
+  nativeCurrency: { name: "Sepolia Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: {
+    default: { http: ["https://sepolia.base.org"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Basescan",
+      url: "https://sepolia.basescan.org",
+      apiUrl: "https://api-sepolia.basescan.org/api",
+    },
+  },
+  contracts: {
+    ...chainConfig.contracts,
+    disputeGameFactory: {
+      [sepoliaSourceId]: {
+        address: "0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1",
+      },
+    },
+    l2OutputOracle: {
+      [sepoliaSourceId]: {
+        address: "0x84457ca9D0163FbC4bbfe4Dfbb20ba46e48DF254",
+      },
+    },
+    portal: {
+      [sepoliaSourceId]: {
+        address: "0x49f53e41452c74589e85ca1677426ba426459e85",
+        blockCreated: 4_446_677,
+      },
+    },
+    l1StandardBridge: {
+      [sepoliaSourceId]: {
+        address: "0xfd0Bf71F60660E2f608ed56e1659C450eB113120",
+        blockCreated: 4_446_677,
+      },
+    },
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 1_059_647,
+    },
+  },
+  testnet: true,
+  sourceId: sepoliaSourceId,
+});
+
+export const arbitrum = defineChain({
+  id: 42_161,
+  name: "Arbitrum One",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  blockTime: 250,
+  rpcUrls: {
+    default: { http: ["https://arb1.arbitrum.io/rpc"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Arbiscan",
+      url: "https://arbiscan.io",
+      apiUrl: "https://api.arbiscan.io/api",
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 7_654_707,
+    },
+  },
+});
+
+export const arbitrumSepolia = defineChain({
+  id: 421_614,
+  name: "Arbitrum Sepolia",
+  blockTime: 250,
+  nativeCurrency: {
+    name: "Arbitrum Sepolia Ether",
+    symbol: "ETH",
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: { http: ["https://sepolia-rollup.arbitrum.io/rpc"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Arbiscan",
+      url: "https://sepolia.arbiscan.io",
+      apiUrl: "https://api-sepolia.arbiscan.io/api",
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 81_930,
+    },
+  },
+  testnet: true,
+});

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -8,7 +8,7 @@ import {
   optimism,
   optimismSepolia,
   sepolia,
-} from "viem/chains";
+} from "./chains.js";
 import {
   jbCcipSuckerDeployerAddress,
   jbContractAddress,
@@ -221,120 +221,125 @@ type SuckerDeployerMap = {
  *
  * @see https://discord.com/channels/1139291093310132376/1139291094069301385/1337164727008366683
  */
-export const CCIP_SUCKER_DEPLOYER_ADDRESSES: Record<5 | 6, SuckerDeployerMap> = {
-  6: jbCcipSuckerDeployerAddress[6] as SuckerDeployerMap,
-  5: {
-    [sepolia.id]: {
-      [optimismSepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
-          sepolia.id
-        ],
-      [baseSepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
-          sepolia.id
-        ],
-      [arbitrumSepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
-          sepolia.id
-        ],
-    },
-    [mainnet.id]: {
-      [optimism.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
-          mainnet.id
-        ],
-      [base.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
-          mainnet.id
-        ],
-      [arbitrum.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
-          mainnet.id
-        ],
-    },
+export const CCIP_SUCKER_DEPLOYER_ADDRESSES: Record<5 | 6, SuckerDeployerMap> =
+  {
+    6: jbCcipSuckerDeployerAddress[6] as SuckerDeployerMap,
+    5: {
+      [sepolia.id]: {
+        [optimismSepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
+            sepolia.id
+          ],
+        [baseSepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
+            sepolia.id
+          ],
+        [arbitrumSepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
+            sepolia.id
+          ],
+      },
+      [mainnet.id]: {
+        [optimism.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
+            mainnet.id
+          ],
+        [base.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
+            mainnet.id
+          ],
+        [arbitrum.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
+            mainnet.id
+          ],
+      },
 
-    [arbitrumSepolia.id]: {
-      [sepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
-          arbitrumSepolia.id
-        ],
-      [optimismSepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
-          arbitrumSepolia.id
-        ],
-      [baseSepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
-          arbitrumSepolia.id
-        ],
-    },
-    [arbitrum.id]: {
-      [mainnet.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
-          arbitrum.id
-        ],
-      [optimism.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
-          arbitrum.id
-        ],
-      [base.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
-          arbitrum.id
-        ],
-    },
+      [arbitrumSepolia.id]: {
+        [sepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
+            arbitrumSepolia.id
+          ],
+        [optimismSepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
+            arbitrumSepolia.id
+          ],
+        [baseSepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
+            arbitrumSepolia.id
+          ],
+      },
+      [arbitrum.id]: {
+        [mainnet.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
+            arbitrum.id
+          ],
+        [optimism.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
+            arbitrum.id
+          ],
+        [base.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
+            arbitrum.id
+          ],
+      },
 
-    [optimismSepolia.id]: {
-      [sepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
-          optimismSepolia.id
-        ],
-      [arbitrumSepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
-          optimismSepolia.id
-        ],
-      [baseSepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
-          optimismSepolia.id
-        ],
-    },
-    [optimism.id]: {
-      [mainnet.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
-          optimism.id
-        ],
-      [arbitrum.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
-          optimism.id
-        ],
-      [base.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
-          optimism.id
-        ],
-    },
+      [optimismSepolia.id]: {
+        [sepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
+            optimismSepolia.id
+          ],
+        [arbitrumSepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
+            optimismSepolia.id
+          ],
+        [baseSepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
+            optimismSepolia.id
+          ],
+      },
+      [optimism.id]: {
+        [mainnet.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
+            optimism.id
+          ],
+        [arbitrum.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
+            optimism.id
+          ],
+        [base.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
+            optimism.id
+          ],
+      },
 
-    [baseSepolia.id]: {
-      [sepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
-          baseSepolia.id
-        ],
-      [optimismSepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
-          baseSepolia.id
-        ],
-      [arbitrumSepolia.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
-          baseSepolia.id
-        ],
+      [baseSepolia.id]: {
+        [sepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][
+            baseSepolia.id
+          ],
+        [optimismSepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
+            baseSepolia.id
+          ],
+        [arbitrumSepolia.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
+            baseSepolia.id
+          ],
+      },
+      [base.id]: {
+        [mainnet.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][base.id],
+        [optimism.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][
+            base.id
+          ],
+        [arbitrum.id]:
+          jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][
+            base.id
+          ],
+      },
     },
-    [base.id]: {
-      [mainnet.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer][base.id],
-      [optimism.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_1][base.id],
-      [arbitrum.id]:
-        jbContractAddress[5][JBSuckerContracts.JBCCIPSuckerDeployer_2][base.id],
-    },
-  },
-};
+  };
 
 /**
  * Native-bridge (OP/Base/Arbitrum standard bridge) sucker deployer addresses, keyed by

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -7,10 +7,11 @@ const repositoryUrl = "https://github.com/Bananapus/juice-sdk-v4";
 const budgets = {
   "@bananapus/nana-sdk-core": {
     directory: "packages/core",
-    // Includes the public Bendystraw transport in both ESM and CJS formats.
-    packed: 752_000,
+    // Includes the public Bendystraw transport and explicit supported-chain
+    // definitions in both ESM and CJS formats.
+    packed: 775_000,
     unpacked: 16_800_000,
-    entries: 354,
+    entries: 365,
   },
   "@bananapus/nana-sdk-react": {
     directory: "packages/react",

--- a/test/format-debt.json
+++ b/test/format-debt.json
@@ -4,7 +4,6 @@
     "packages/core/src/actions/dataHook.ts": "cfafa2de17fd6dfc304ac62228474a84ff81500fa6f60881a284bc722911346f",
     "packages/core/src/actions/projectMetadata.ts": "0ba218a2d82d72502e833b09ada6f6bd31443f0f95a1696c0965b6b9d1ef4ba9",
     "packages/core/src/actions/suckerPairs.ts": "8bb2100df8dfc93624f26dcf940afedccf3e1a86de5b4d203c1ccd6336391ab2",
-    "packages/core/src/constants.ts": "74c45a310baada51ee77553f7b6744d8d0e14fed4f3680f3a972e4c230914e2d",
     "packages/core/src/generated/juicebox.ts": "a6f98fb29e962603a07eabc17ae59a114f6e844aacc5aef0b9b1191313e7896b",
     "packages/core/src/utils/data.test.ts": "52351beb5598aaa08bd81c1e034ca8746aba34ceaa9df030abd0cdc940ab30ad",
     "packages/core/src/utils/deploy.test.ts": "c21f4d32330465ca934520db491c4408c2fba7cd17e0bf64a233377f4df4a682",


### PR DESCRIPTION
## What changed

- defines the eight Juicebox-supported chains directly from public `viem` primitives instead of importing the full `viem/chains` barrel
- adds parity tests that deep-compare every local definition with viem’s upstream definition
- clears the touched constants formatting debt and adjusts the package budget for the explicit ESM/CJS definitions
- adds a patch changeset for `@bananapus/nana-sdk-core`

## Why

The `viem/chains` barrel exposes every chain. Client bundlers followed that barrel into Tempo’s runtime-only virtual master-pool module, causing a critical-dependency warning in otherwise unrelated Juicebox Money builds. Keeping the supported definitions explicit removes that transitive build behavior while preserving the exact chain objects consumers receive.

## Impact

SDK consumers retain the same `JB_CHAINS` API and chain configuration. Browser builds no longer pull the all-chain barrel through this SDK path.

## Validation

- full `npm run check`
- 314 core tests and 126 React tests pass with coverage
- chain parity tests cover all eight supported chains
- type checks, generated GraphQL/contract parity, protocol and wallet checks, builds, and package budgets pass