### PR TITLE
Preserve JB_CHAINS literal chain ID types

### DIFF
--- a/.changeset/strong-chains-type.md
+++ b/.changeset/strong-chains-type.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-core": patch
+---
+
+Preserve literal chain ID types when reading supported chain metadata from `JB_CHAINS`.

--- a/packages/core/src/chains.test.ts
+++ b/packages/core/src/chains.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import {
   arbitrum as viemArbitrum,
   arbitrumSepolia as viemArbitrumSepolia,
@@ -19,6 +19,7 @@ import {
   optimismSepolia,
   sepolia,
 } from "./chains.js";
+import { JB_CHAINS } from "./constants.js";
 
 describe("supported chain definitions", () => {
   it.each([
@@ -32,5 +33,16 @@ describe("supported chain definitions", () => {
     ["arbitrumSepolia", arbitrumSepolia, viemArbitrumSepolia],
   ])("keeps %s aligned with viem", (_name, local, upstream) => {
     expect(local).toEqual(upstream);
+  });
+
+  it("preserves each JB_CHAINS key as its chain's literal ID type", () => {
+    expectTypeOf(JB_CHAINS[1].chain.id).toEqualTypeOf<1>();
+    expectTypeOf(JB_CHAINS[10].chain.id).toEqualTypeOf<10>();
+    expectTypeOf(JB_CHAINS[8453].chain.id).toEqualTypeOf<8453>();
+    expectTypeOf(JB_CHAINS[42161].chain.id).toEqualTypeOf<42161>();
+    expectTypeOf(JB_CHAINS[11155111].chain.id).toEqualTypeOf<11155111>();
+    expectTypeOf(JB_CHAINS[11155420].chain.id).toEqualTypeOf<11155420>();
+    expectTypeOf(JB_CHAINS[84532].chain.id).toEqualTypeOf<84532>();
+    expectTypeOf(JB_CHAINS[421614].chain.id).toEqualTypeOf<421614>();
   });
 });

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -127,15 +127,17 @@ export const NATIVE_TOKEN_DECIMALS = 18 as const;
  */
 export const JBDAO_CASHOUT_FEE_PERCENT = 0.025;
 
-type JBChainMetadata = {
-  chain: Chain;
+type JBChainMetadata<ChainId extends JBChainId = JBChainId> = {
+  chain: Chain & { id: ChainId };
   name: string;
   slug: string;
   nativeTokenSymbol: string;
   etherscanHostname: string;
 };
 
-export const JB_CHAINS: Record<JBChainId, JBChainMetadata> = {
+export const JB_CHAINS: {
+  [ChainId in JBChainId]: JBChainMetadata<ChainId>;
+} = {
   [sepolia.id]: {
     chain: sepolia,
     name: "Sepolia",


### PR DESCRIPTION
## Summary

- preserve each `JB_CHAINS[key].chain.id` as that key's literal `JBChainId` type
- add compile-time regression assertions for all eight supported chains
- add a patch changeset for `@bananapus/nana-sdk-core`

## Validation

- `npm run type-check --workspace @bananapus/nana-sdk-core`
- `npm test --workspace @bananapus/nana-sdk-core -- --run src/chains.test.ts`
- `npm run check` (315 core tests and 126 React tests passed; builds, generated outputs, package budgets, protocol checks, and type checks passed)