### PR TITLE
chore: add SDK release changeset

### DIFF
--- a/.changeset/clean-sdk-surface.md
+++ b/.changeset/clean-sdk-surface.md
@@ -1,0 +1,6 @@
+---
+"@bananapus/nana-sdk-core": patch
+"@bananapus/nana-sdk-react": patch
+---
+
+Harden contract deployment lookup and Bendystraw operation handling while removing unused generated GraphQL and runtime surface.


### PR DESCRIPTION
## Summary

Add the missing patch Changeset for both published SDK packages after #71.

## Why

PR #71 changed Core deployment lookup behavior and React Bendystraw/query-generation behavior, but merged without release metadata. Core had already released `1.9.2`, and React remained at `10.0.0`, so neither package had a pending Changeset covering that PR.

This queues the Changesets release workflow to prepare:

- `@bananapus/nana-sdk-core` `1.9.3`
- `@bananapus/nana-sdk-react` `10.0.1`

## Validation

- `changeset status` recognizes both packages as patch bumps
- `git diff --check`
