### PR TITLE
Add canonical cash-out routing

### DIFF
--- a/.changeset/canonical-cash-out-routing.md
+++ b/.changeset/canonical-cash-out-routing.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-core": patch
+---
+
+Correct buyback cash-out slippage routing; add best-execution selection across direct pool sales and terminal cash-outs, locked transaction preparation, and typed diagnostics; and normalize Uniswap V4 tick and price ranges across currency orderings.

--- a/packages/core/src/v6/cashOut.test.ts
+++ b/packages/core/src/v6/cashOut.test.ts
@@ -12,10 +12,16 @@ import {
   build721CashOutMetadata,
   buildBuybackCashOutMetadata,
   buildCashOutTx,
+  cashOutPoolBufferBps,
   cashOutProtocolFee,
+  chooseBestCashOutRoute,
+  classifyCashOutExecutionError,
   decodeBuybackCashOutSpec,
+  getBestCashOutRoute,
   getCashOutQuote,
   getHookAwareCashOutQuote,
+  prepareBestCashOut,
+  prepareHookAwareCashOut,
   resolveCashOutRoute,
   slippageFloor,
 } from "./cashOut.js";
@@ -251,10 +257,10 @@ describe("hook-aware cash-out routing", () => {
     });
     expect(route.route).toEqual("amm");
     expect(route.expectedReturn).toEqual(1_200n);
-    expect(route.minimumReturn).toEqual(1_188n);
+    expect(route.minimumReturn).toEqual(1_089n);
     expect(route.terminalMinimum).toEqual(0n);
     expect(route.metadata).toEqual(
-      buildBuybackCashOutMetadata({ hook, minimumSwapAmountOut: 1_188n }),
+      buildBuybackCashOutMetadata({ hook, minimumSwapAmountOut: 1_089n }),
     );
   });
 
@@ -278,6 +284,38 @@ describe("hook-aware cash-out routing", () => {
     });
     expect(route.route).toEqual("amm");
     expect(route.minimumReturn).toEqual(1_188n);
+  });
+
+  test("uses the executable pool quote rather than the optimistic raw quote", () => {
+    const route = resolveCashOutRoute({
+      reclaimAmount: 1_510_000n,
+      cashOutTaxRate: 1n,
+      hookSpecifications: [
+        {
+          hook,
+          noop: false,
+          amount: 0n,
+          metadata: specMetadata({
+            minimumSwap: 16_000_000n,
+            netDirect: 1_470_000n,
+            rawQuote: 16_419_630n,
+          }),
+        },
+      ],
+      buybackHookAddress: hook,
+      slippageBps: 100n,
+    });
+
+    expect(route.route).toEqual("amm");
+    expect(route.expectedReturn).toEqual(16_419_630n);
+    expect(route.minimumReturn).toEqual(15_840_000n);
+    expect(cashOutPoolBufferBps(route)).toEqual(256n);
+    expect(route.metadata).toEqual(
+      buildBuybackCashOutMetadata({
+        hook,
+        minimumSwapAmountOut: 15_840_000n,
+      }),
+    );
   });
 
   test("noop spec stays on the treasury path", () => {
@@ -418,8 +456,210 @@ describe("hook-aware cash-out routing", () => {
     expect(route.expectedReturn).toEqual(1_200n);
     expect(route.buyback?.hook).toEqual(hook);
     expect(route.metadata).toEqual(
-      buildBuybackCashOutMetadata({ hook, minimumSwapAmountOut: 1_188n }),
+      buildBuybackCashOutMetadata({ hook, minimumSwapAmountOut: 1_089n }),
     );
+  });
+
+  test("classifies nested cash-out execution errors without owning UI copy", () => {
+    expect(
+      classifyCashOutExecutionError({
+        message: "execution reverted",
+        cause: { details: "reverted with signature 0xe2d708a9" },
+      }),
+    ).toEqual({
+      code: "BUYBACK_SLIPPAGE_EXCEEDED",
+      selector: "0xe2d708a9",
+    });
+    expect(
+      classifyCashOutExecutionError({
+        cause: { errorName: "JBMultiTerminal_UnderMin" },
+      }),
+    ).toEqual({ code: "TERMINAL_UNDER_MIN", selector: "0x6b2bb382" });
+    expect(
+      classifyCashOutExecutionError(new Error("user rejected")),
+    ).toBeNull();
+  });
+
+  test("chooses a direct sale only for claimed tokens with a strictly better protected output", () => {
+    const cashOut = resolveCashOutRoute({
+      reclaimAmount: 1_000n,
+      cashOutTaxRate: 1n,
+      hookSpecifications: [],
+    });
+    const poolKey = {
+      currency0: holder,
+      currency1: "0x0000000000000000000000000000000000000000",
+      fee: 10_000,
+      tickSpacing: 200,
+      hooks: hook,
+    } as const;
+
+    expect(
+      chooseBestCashOutRoute({
+        cashOut,
+        directSwapQuote: 1_000n,
+        directSwapPoolKey: poolKey,
+        directSwapZeroForOne: true,
+        spendableProjectTokenCount: 100n,
+        cashOutCount: 100n,
+      }),
+    ).toMatchObject({
+      kind: "direct-swap",
+      expectedReturn: 1_000n,
+      minimumReturn: 990n,
+    });
+    expect(
+      chooseBestCashOutRoute({
+        cashOut,
+        directSwapQuote: 1_000n,
+        directSwapPoolKey: poolKey,
+        directSwapZeroForOne: true,
+        spendableProjectTokenCount: 99n,
+        cashOutCount: 100n,
+      }).kind,
+    ).toEqual("cash-out");
+    expect(
+      chooseBestCashOutRoute({
+        cashOut,
+        directSwapQuote: 980n,
+        directSwapPoolKey: poolKey,
+        directSwapZeroForOne: true,
+        spendableProjectTokenCount: 100n,
+        cashOutCount: 100n,
+      }).kind,
+    ).toEqual("cash-out");
+  });
+
+  test("quotes and prepares a direct native-pair sale when it safely beats cashing out", async () => {
+    const projectToken = "0x7777777777777777777777777777777777777777" as const;
+    const poolKey = {
+      currency0: "0x0000000000000000000000000000000000000000",
+      currency1: projectToken,
+      fee: 10_000,
+      tickSpacing: 200,
+      hooks: hook,
+    } as const;
+    const calls: string[] = [];
+    const client = {
+      readContract: async (call: { functionName: string }) => {
+        calls.push(call.functionName);
+        if (call.functionName === "previewCashOutFrom") {
+          return [{ id: 42n }, 1_000n, 1n, []];
+        }
+        throw new Error(`unexpected call ${call.functionName}`);
+      },
+      call: async () => {
+        calls.push("quoteExactInputSingle");
+        return {
+          data: encodeAbiParameters(
+            [{ type: "uint256" }, { type: "uint256" }],
+            [1_200n, 50_000n],
+          ),
+        };
+      },
+    } as unknown as PublicClient;
+    const args = {
+      chainId,
+      projectId,
+      holder,
+      cashOutCount: 100n,
+      tokenToReclaim: NATIVE_TOKEN,
+      directSwap: {
+        poolKey,
+        projectToken,
+        spendableProjectTokenCount: 100n,
+      },
+    } as const;
+
+    const best = await getBestCashOutRoute(client, args);
+    expect(best).toMatchObject({
+      kind: "direct-swap",
+      expectedReturn: 1_200n,
+      minimumReturn: 1_188n,
+      zeroForOne: false,
+    });
+
+    const prepared = await prepareBestCashOut(client, {
+      ...args,
+      beneficiary,
+      directSwapDeadline: 123_456n,
+    });
+    expect(prepared.kind).toEqual("direct-swap");
+    if (prepared.kind !== "direct-swap") throw new Error("expected swap");
+    expect(prepared.transaction.functionName).toEqual("execute");
+    expect(prepared.transaction.args[2]).toEqual(123_456n);
+    expect(prepared.route.minimumReturn).toEqual(1_188n);
+    expect(calls).toEqual([
+      "previewCashOutFrom",
+      "quoteExactInputSingle",
+      "previewCashOutFrom",
+      "quoteExactInputSingle",
+    ]);
+  });
+
+  test("does not quote a pool whose output is not the reclaim token", async () => {
+    const projectToken = "0x7777777777777777777777777777777777777777" as const;
+    let poolCalls = 0;
+    const client = {
+      readContract: async () => [{ id: 42n }, 1_000n, 1n, []],
+      call: async () => {
+        poolCalls += 1;
+        throw new Error("should not quote");
+      },
+    } as unknown as PublicClient;
+    const best = await getBestCashOutRoute(client, {
+      chainId,
+      projectId,
+      holder,
+      cashOutCount: 100n,
+      tokenToReclaim: NATIVE_TOKEN,
+      directSwap: {
+        projectToken,
+        spendableProjectTokenCount: 100n,
+        poolKey: {
+          currency0: projectToken,
+          currency1: beneficiary,
+          fee: 10_000,
+          tickSpacing: 200,
+          hooks: hook,
+        },
+      },
+    });
+    expect(best.kind).toEqual("cash-out");
+    expect(poolCalls).toEqual(0);
+  });
+
+  test("falls back to the terminal when the optional direct-swap quoter fails", async () => {
+    const projectToken = "0x7777777777777777777777777777777777777777" as const;
+    const client = {
+      readContract: async () => [{ id: 42n }, 1_000n, 1n, []],
+      call: async () => {
+        throw new Error("quoter unavailable");
+      },
+    } as unknown as PublicClient;
+    const best = await getBestCashOutRoute(client, {
+      chainId,
+      projectId,
+      holder,
+      cashOutCount: 100n,
+      tokenToReclaim: NATIVE_TOKEN,
+      directSwap: {
+        projectToken,
+        spendableProjectTokenCount: 100n,
+        poolKey: {
+          currency0: projectToken,
+          currency1: "0x0000000000000000000000000000000000000000",
+          fee: 10_000,
+          tickSpacing: 200,
+          hooks: hook,
+        },
+      },
+    });
+    expect(best).toMatchObject({
+      kind: "cash-out",
+      expectedReturn: 975n,
+      minimumReturn: 965n,
+    });
   });
 
   test("getHookAwareCashOutQuote reads previewCashOutFrom and resolves", async () => {
@@ -503,5 +743,98 @@ describe("hook-aware cash-out routing", () => {
     expect(treasuryRoute.terminalMinimum).toEqual(965n);
     expect(treasuryRoute.metadata).toEqual("0x");
     expect(treasuryRoute.buyback).toBeNull();
+  });
+
+  test("prepareHookAwareCashOut locks the pool route and builds its transaction", async () => {
+    const buybackHook = v6Address("JBBuybackHook", chainId);
+    const calls: { functionName: string; args: readonly unknown[] }[] = [];
+    const client = {
+      readContract: async (call: {
+        functionName: string;
+        args: readonly unknown[];
+      }) => {
+        calls.push(call);
+        if (call.functionName !== "previewCashOutFrom") {
+          throw new Error(`unexpected call ${call.functionName}`);
+        }
+        const metadata = call.args[5];
+        return [
+          { id: 42n },
+          0n,
+          10_000n,
+          [
+            {
+              hook: buybackHook,
+              noop: false,
+              amount: 0n,
+              metadata:
+                metadata === "0x"
+                  ? specMetadata()
+                  : specMetadata({
+                      minimumSwap: 1_089n,
+                      rawQuote: 0n,
+                      userSpecified: true,
+                    }),
+            },
+          ],
+        ];
+      },
+    } as unknown as PublicClient;
+
+    const prepared = await prepareHookAwareCashOut(client, {
+      chainId,
+      projectId,
+      holder,
+      cashOutCount: ONE_ETHER,
+      tokenToReclaim: NATIVE_TOKEN,
+      beneficiary,
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(prepared.preview.rulesetId).toEqual(42n);
+    expect(prepared.lockedPreview?.rulesetId).toEqual(42n);
+    expect(prepared.route.route).toEqual("amm");
+    expect(prepared.route.minimumReturn).toEqual(1_089n);
+    expect(prepared.transaction.args[4]).toEqual(0n);
+    expect(prepared.transaction.args[5]).toEqual(beneficiary);
+    expect(prepared.transaction.args[6]).toEqual(prepared.route.metadata);
+  });
+
+  test("prepareHookAwareCashOut rejects a route which changes while locking", async () => {
+    const buybackHook = v6Address("JBBuybackHook", chainId);
+    let previewCount = 0;
+    const client = {
+      readContract: async (call: { functionName: string }) => {
+        if (call.functionName !== "previewCashOutFrom") {
+          throw new Error(`unexpected call ${call.functionName}`);
+        }
+        previewCount += 1;
+        return [
+          { id: 42n },
+          previewCount === 1 ? 0n : 1_000n,
+          previewCount === 1 ? 10_000n : 1n,
+          previewCount === 1
+            ? [
+                {
+                  hook: buybackHook,
+                  noop: false,
+                  amount: 0n,
+                  metadata: specMetadata(),
+                },
+              ]
+            : [],
+        ];
+      },
+    } as unknown as PublicClient;
+
+    await expect(
+      prepareHookAwareCashOut(client, {
+        chainId,
+        projectId,
+        holder,
+        cashOutCount: ONE_ETHER,
+        tokenToReclaim: NATIVE_TOKEN,
+      }),
+    ).rejects.toMatchObject({ code: "CASH_OUT_ROUTE_CHANGED" });
   });
 });

--- a/packages/core/src/v6/cashOut.ts
+++ b/packages/core/src/v6/cashOut.ts
@@ -14,6 +14,13 @@ import { applyJbDaoCashOutFee } from "../utils/fee.js";
 import { createHookMetadata, hookMetadataId } from "../utils/hook.js";
 import { NATIVE_TOKEN_CURRENCY_ID } from "./currency.js";
 import { v6Address } from "./types.js";
+import {
+  buildUniswapV4ExactInputSwapTx,
+  quoteUniswapV4ExactInputSingle,
+  uniswapV4SwapDirection,
+  type UniswapV4PoolKey,
+  type UniswapV4SwapTxRequest,
+} from "./uniswapV4.js";
 
 /**
  * A prepared `cashOutTokensOf` transaction request, accepted as-is by viem's
@@ -397,6 +404,170 @@ export interface CashOutRoute {
   buyback: (BuybackCashOutSpec & { hook: Address }) | null;
 }
 
+/** A terminal cash out or a direct sale of already-claimed project ERC-20s. */
+export type BestCashOutRoute =
+  | {
+      kind: "cash-out";
+      expectedReturn: bigint;
+      minimumReturn: bigint;
+      cashOut: CashOutRoute;
+    }
+  | {
+      kind: "direct-swap";
+      expectedReturn: bigint;
+      minimumReturn: bigint;
+      /** The displaced terminal route, retained for comparison and fallback. */
+      cashOut: CashOutRoute;
+      poolKey: UniswapV4PoolKey;
+      zeroForOne: boolean;
+    };
+
+/**
+ * Pick the executable exit which guarantees the holder the most reclaim token.
+ *
+ * A direct pool sale can only spend claimed ERC-20s. Internal Juicebox credits
+ * stay on the terminal route until they are claimed. The direct route must beat
+ * the terminal's full expected output even after user slippage; an optimistic
+ * pool quote alone is never enough to displace a deterministic cash out.
+ */
+export function chooseBestCashOutRoute({
+  cashOut,
+  directSwapQuote,
+  directSwapPoolKey,
+  directSwapZeroForOne,
+  spendableProjectTokenCount = 0n,
+  cashOutCount,
+  slippageBps = DEFAULT_CASH_OUT_SLIPPAGE_BPS,
+}: {
+  cashOut: CashOutRoute;
+  directSwapQuote?: bigint | null;
+  directSwapPoolKey?: UniswapV4PoolKey;
+  directSwapZeroForOne?: boolean;
+  spendableProjectTokenCount?: bigint;
+  cashOutCount: bigint;
+  slippageBps?: bigint;
+}): BestCashOutRoute {
+  const cashOutCandidate: BestCashOutRoute = {
+    kind: "cash-out",
+    expectedReturn: cashOut.expectedReturn,
+    minimumReturn: cashOut.minimumReturn,
+    cashOut,
+  };
+  if (
+    !directSwapQuote ||
+    directSwapQuote <= 0n ||
+    !directSwapPoolKey ||
+    directSwapZeroForOne === undefined ||
+    cashOutCount <= 0n ||
+    spendableProjectTokenCount < cashOutCount
+  ) {
+    return cashOutCandidate;
+  }
+
+  const minimumReturn = slippageFloor(directSwapQuote, slippageBps);
+  if (minimumReturn <= cashOut.expectedReturn) return cashOutCandidate;
+
+  return {
+    kind: "direct-swap",
+    expectedReturn: directSwapQuote,
+    minimumReturn,
+    cashOut,
+    poolKey: directSwapPoolKey,
+    zeroForOne: directSwapZeroForOne,
+  };
+}
+
+export interface DirectCashOutSwapArguments {
+  poolKey: UniswapV4PoolKey;
+  projectToken: Address;
+  /** Claimed ERC-20 balance available to the Universal Router. */
+  spendableProjectTokenCount: bigint;
+}
+
+export interface BestCashOutArguments extends HookAwareCashOutArguments {
+  directSwap?: DirectCashOutSwapArguments;
+}
+
+/** Pool fee/impact already reflected by the buyback hook's executable quote. */
+export function cashOutPoolBufferBps(
+  route: CashOutRoute | null | undefined,
+): bigint | null {
+  const buyback = route?.route === "amm" ? route.buyback : null;
+  if (!buyback || buyback.rawSwapQuote <= 0n) return null;
+  const executableQuote =
+    buyback.minimumSwapAmountOut > buyback.rawSwapQuote
+      ? buyback.rawSwapQuote
+      : buyback.minimumSwapAmountOut;
+  return (
+    ((buyback.rawSwapQuote - executableQuote) * MAX_BPS +
+      buyback.rawSwapQuote -
+      1n) /
+    buyback.rawSwapQuote
+  );
+}
+
+/** Machine-readable cash-out failures which clients can translate into copy. */
+export type CashOutExecutionErrorCode =
+  | "BUYBACK_SLIPPAGE_EXCEEDED"
+  | "TERMINAL_UNDER_MIN";
+
+export interface CashOutExecutionError {
+  code: CashOutExecutionErrorCode;
+  selector: Hex;
+}
+
+const CASH_OUT_EXECUTION_ERRORS: readonly (CashOutExecutionError & {
+  matchers: readonly string[];
+})[] = [
+  {
+    code: "BUYBACK_SLIPPAGE_EXCEEDED",
+    selector: "0xe2d708a9",
+    matchers: ["0xe2d708a9", "jbbuybackhook_specifiedslippageexceeded"],
+  },
+  {
+    code: "TERMINAL_UNDER_MIN",
+    selector: "0x6b2bb382",
+    matchers: ["0x6b2bb382", "jbmultiterminal_undermin"],
+  },
+] as const;
+
+function collectCashOutErrorText(
+  value: unknown,
+  seen = new Set<unknown>(),
+  depth = 0,
+): string[] {
+  if (depth > 8 || value === null || value === undefined || seen.has(value)) {
+    return [];
+  }
+  if (typeof value === "string") return [value];
+  if (typeof value !== "object") return [];
+  seen.add(value);
+  const record = value as Record<string, unknown>;
+  return [
+    record.shortMessage,
+    record.message,
+    record.details,
+    record.errorName,
+    record.signature,
+    record.raw,
+    record.data,
+    record.cause,
+    record.error,
+  ].flatMap((item) => collectCashOutErrorText(item, seen, depth + 1));
+}
+
+/** Classify known cash-out errors through viem/wallet nested error shapes. */
+export function classifyCashOutExecutionError(
+  error: unknown,
+): CashOutExecutionError | null {
+  const text = collectCashOutErrorText(error).join(" | ").toLowerCase();
+  if (!text) return null;
+  const matched = CASH_OUT_EXECUTION_ERRORS.find(({ matchers }) =>
+    matchers.some((matcher) => text.includes(matcher)),
+  );
+  return matched ? { code: matched.code, selector: matched.selector } : null;
+}
+
 /**
  * Interpret a hook-aware `previewCashOutFrom` result and prepare a
  * slippage-protected route.
@@ -481,16 +652,23 @@ export function resolveCashOutRoute({
 
   if (!specification || specification.noop || !buyback) return treasuryRoute;
 
-  // The pool route won the preview. Re-previews with an explicit metadata
-  // minimum report that already-protected floor and no raw quote — preserve
-  // it instead of discounting a second time.
+  // The raw swap quote is an optimistic oracle quote used for display and
+  // route comparison. The hook's minimumSwapAmountOut is the executable pool
+  // quote after fee, liquidity, and price-impact constraints. User slippage
+  // must be applied to that executable value; applying it to rawSwapQuote can
+  // create a minimum the pool cannot satisfy.
   const quote =
     buyback.rawSwapQuote > 0n
       ? buyback.rawSwapQuote
       : buyback.minimumSwapAmountOut;
+  const executableQuote =
+    buyback.rawSwapQuote > 0n &&
+    buyback.minimumSwapAmountOut > buyback.rawSwapQuote
+      ? buyback.rawSwapQuote
+      : buyback.minimumSwapAmountOut;
   const minimumReturn =
     buyback.rawSwapQuote > 0n && !buyback.hasUserSpecifiedMinimumSwapAmountOut
-      ? slippageFloor(quote, slippageBps)
+      ? slippageFloor(executableQuote, slippageBps)
       : buyback.minimumSwapAmountOut;
 
   // An explicit metadata minimum at or below the direct net routes execution
@@ -545,6 +723,123 @@ export function resolveCashOutRoute({
  * {@link DEFAULT_CASH_OUT_SLIPPAGE_BPS}.
  * @returns The protected route (see {@link CashOutRoute}).
  */
+export interface HookAwareCashOutArguments {
+  chainId: JBChainId;
+  projectId: bigint;
+  holder: Address;
+  cashOutCount: bigint;
+  tokenToReclaim: Address;
+  beneficiary?: Address;
+  terminal?: Address;
+  buybackHookAddress?: Address;
+  beneficiaryIsFeeless?: boolean;
+  slippageBps?: bigint;
+}
+
+/** The protocol facts returned by one `previewCashOutFrom` call. */
+export interface CashOutPreviewSnapshot {
+  rulesetId: bigint | null;
+  reclaimAmount: bigint;
+  cashOutTaxRate: bigint;
+  hookSpecifications: readonly CashOutHookSpecification[];
+}
+
+function rulesetIdOf(ruleset: unknown): bigint | null {
+  const id =
+    ruleset && typeof ruleset === "object" && "id" in ruleset
+      ? (ruleset as { id?: unknown }).id
+      : Array.isArray(ruleset)
+        ? ruleset[0]
+        : null;
+  try {
+    return id === null || id === undefined ? null : BigInt(id as string);
+  } catch {
+    return null;
+  }
+}
+
+async function readCashOutPreviewSnapshot(
+  client: PublicClient,
+  {
+    terminal,
+    holder,
+    projectId,
+    cashOutCount,
+    tokenToReclaim,
+    beneficiary,
+    metadata,
+  }: {
+    terminal: Address;
+    holder: Address;
+    projectId: bigint;
+    cashOutCount: bigint;
+    tokenToReclaim: Address;
+    beneficiary: Address;
+    metadata: Hex;
+  },
+): Promise<CashOutPreviewSnapshot> {
+  const [ruleset, reclaimAmount, cashOutTaxRate, hookSpecifications] =
+    await client.readContract({
+      address: terminal,
+      abi: jbMultiTerminalAbi,
+      functionName: "previewCashOutFrom",
+      args: [
+        holder,
+        projectId,
+        cashOutCount,
+        tokenToReclaim,
+        beneficiary,
+        metadata,
+      ],
+    });
+  return {
+    rulesetId: rulesetIdOf(ruleset),
+    reclaimAmount,
+    cashOutTaxRate,
+    hookSpecifications,
+  };
+}
+
+async function resolveCashOutPreviewSnapshot(
+  client: PublicClient,
+  preview: CashOutPreviewSnapshot,
+  {
+    terminal,
+    projectId,
+    tokenToReclaim,
+    buybackHookAddress,
+    beneficiaryIsFeeless,
+    slippageBps,
+  }: {
+    terminal: Address;
+    projectId: bigint;
+    tokenToReclaim: Address;
+    buybackHookAddress?: Address;
+    beneficiaryIsFeeless: boolean;
+    slippageBps: bigint;
+  },
+): Promise<CashOutRoute> {
+  const feeFreeSurplus =
+    preview.cashOutTaxRate === 0n
+      ? await client.readContract({
+          address: terminal,
+          abi: jbMultiTerminalAbi,
+          functionName: "feeFreeSurplusOf",
+          args: [projectId, tokenToReclaim],
+        })
+      : 0n;
+
+  return resolveCashOutRoute({
+    reclaimAmount: preview.reclaimAmount,
+    cashOutTaxRate: preview.cashOutTaxRate,
+    hookSpecifications: preview.hookSpecifications,
+    buybackHookAddress,
+    beneficiaryIsFeeless,
+    feeFreeSurplus,
+    slippageBps,
+  });
+}
+
 export async function getHookAwareCashOutQuote(
   client: PublicClient,
   {
@@ -553,62 +848,249 @@ export async function getHookAwareCashOutQuote(
     holder,
     cashOutCount,
     tokenToReclaim,
-    beneficiary,
+    beneficiary = holder,
     terminal,
     buybackHookAddress,
     beneficiaryIsFeeless = false,
     slippageBps = DEFAULT_CASH_OUT_SLIPPAGE_BPS,
-  }: {
-    chainId: JBChainId;
-    projectId: bigint;
-    holder: Address;
-    cashOutCount: bigint;
-    tokenToReclaim: Address;
-    beneficiary?: Address;
-    terminal?: Address;
-    buybackHookAddress?: Address;
-    beneficiaryIsFeeless?: boolean;
-    slippageBps?: bigint;
-  },
+  }: HookAwareCashOutArguments,
 ): Promise<CashOutRoute> {
   const terminalAddress = terminal ?? v6Address("JBMultiTerminal", chainId);
   const buybackHook =
     buybackHookAddress ?? optionalV6Address("JBBuybackHook", chainId);
-  const [, reclaimAmount, cashOutTaxRate, hookSpecifications] =
-    await client.readContract({
-      address: terminalAddress,
-      abi: jbMultiTerminalAbi,
-      functionName: "previewCashOutFrom",
-      args: [
-        holder,
-        projectId,
-        cashOutCount,
-        tokenToReclaim,
-        beneficiary ?? holder,
-        "0x",
-      ],
-    });
-
-  // The fee-free surplus counter only matters on zero-tax rulesets.
-  const feeFreeSurplus =
-    cashOutTaxRate === 0n
-      ? await client.readContract({
-          address: terminalAddress,
-          abi: jbMultiTerminalAbi,
-          functionName: "feeFreeSurplusOf",
-          args: [projectId, tokenToReclaim],
-        })
-      : 0n;
-
-  return resolveCashOutRoute({
-    reclaimAmount,
-    cashOutTaxRate,
-    hookSpecifications,
+  const preview = await readCashOutPreviewSnapshot(client, {
+    terminal: terminalAddress,
+    holder,
+    projectId,
+    cashOutCount,
+    tokenToReclaim,
+    beneficiary,
+    metadata: "0x",
+  });
+  return resolveCashOutPreviewSnapshot(client, preview, {
+    terminal: terminalAddress,
+    projectId,
+    tokenToReclaim,
     buybackHookAddress: buybackHook,
     beneficiaryIsFeeless,
-    feeFreeSurplus,
     slippageBps,
   });
+}
+
+/**
+ * Quote the best user exit across the terminal and a directly spendable pool.
+ *
+ * `previewCashOutFrom` remains the source of truth for terminal and buyback-hook
+ * settlement. When a matching pool and sufficient claimed ERC-20 balance are
+ * supplied, the V4 Quoter is read as well and a direct swap wins only when its
+ * slippage-protected minimum exceeds the terminal route's full expected output.
+ */
+export async function getBestCashOutRoute(
+  client: PublicClient,
+  args: BestCashOutArguments,
+): Promise<BestCashOutRoute> {
+  const cashOut = await getHookAwareCashOutQuote(client, args);
+  const directSwap = args.directSwap;
+  if (
+    !directSwap ||
+    directSwap.spendableProjectTokenCount < args.cashOutCount ||
+    args.cashOutCount <= 0n
+  ) {
+    return chooseBestCashOutRoute({
+      cashOut,
+      cashOutCount: args.cashOutCount,
+      slippageBps: args.slippageBps,
+    });
+  }
+
+  const zeroForOne = uniswapV4SwapDirection({
+    poolKey: directSwap.poolKey,
+    tokenIn: directSwap.projectToken,
+    tokenOut: args.tokenToReclaim,
+  });
+  if (zeroForOne === null) {
+    return chooseBestCashOutRoute({
+      cashOut,
+      cashOutCount: args.cashOutCount,
+      slippageBps: args.slippageBps,
+    });
+  }
+
+  let directSwapQuote: bigint;
+  try {
+    directSwapQuote = await quoteUniswapV4ExactInputSingle(client, {
+      chainId: args.chainId,
+      poolKey: directSwap.poolKey,
+      zeroForOne,
+      amountIn: args.cashOutCount,
+    });
+  } catch {
+    // The direct pool is an optional optimization. A missing/reverting quoter
+    // must not make an otherwise valid terminal cash out unavailable.
+    return chooseBestCashOutRoute({
+      cashOut,
+      cashOutCount: args.cashOutCount,
+      slippageBps: args.slippageBps,
+    });
+  }
+  return chooseBestCashOutRoute({
+    cashOut,
+    directSwapQuote,
+    directSwapPoolKey: directSwap.poolKey,
+    directSwapZeroForOne: zeroForOne,
+    spendableProjectTokenCount: directSwap.spendableProjectTokenCount,
+    cashOutCount: args.cashOutCount,
+    slippageBps: args.slippageBps,
+  });
+}
+
+export class CashOutRouteChangedError extends Error {
+  readonly code = "CASH_OUT_ROUTE_CHANGED";
+
+  constructor() {
+    super(
+      "The cash-out route changed while its executable minimum was being locked.",
+    );
+    this.name = "CashOutRouteChangedError";
+  }
+}
+
+/** A fresh quote, locked AMM preview, and matching transaction request. */
+export interface PreparedHookAwareCashOut {
+  route: CashOutRoute;
+  transaction: V6CashOutTxRequest;
+  preview: CashOutPreviewSnapshot;
+  lockedPreview: CashOutPreviewSnapshot | null;
+}
+
+export type PreparedBestCashOut =
+  | ({ kind: "cash-out" } & PreparedHookAwareCashOut)
+  | {
+      kind: "direct-swap";
+      route: Extract<BestCashOutRoute, { kind: "direct-swap" }>;
+      transaction: UniswapV4SwapTxRequest;
+    };
+
+/**
+ * Prepare the exact hook-aware cash-out request a wallet should submit.
+ *
+ * Pool routes are re-previewed with their slippage metadata before the request
+ * is returned. This proves the executable minimum still selects the same route
+ * and avoids clients independently composing a stale quote and transaction.
+ */
+export async function prepareHookAwareCashOut(
+  client: PublicClient,
+  {
+    chainId,
+    projectId,
+    holder,
+    cashOutCount,
+    tokenToReclaim,
+    beneficiary = holder,
+    terminal,
+    buybackHookAddress,
+    beneficiaryIsFeeless = false,
+    slippageBps = DEFAULT_CASH_OUT_SLIPPAGE_BPS,
+  }: HookAwareCashOutArguments,
+): Promise<PreparedHookAwareCashOut> {
+  const terminalAddress = terminal ?? v6Address("JBMultiTerminal", chainId);
+  const buybackHook =
+    buybackHookAddress ?? optionalV6Address("JBBuybackHook", chainId);
+  const resolvePreview = (preview: CashOutPreviewSnapshot) =>
+    resolveCashOutPreviewSnapshot(client, preview, {
+      terminal: terminalAddress,
+      projectId,
+      tokenToReclaim,
+      buybackHookAddress: buybackHook,
+      beneficiaryIsFeeless,
+      slippageBps,
+    });
+
+  const preview = await readCashOutPreviewSnapshot(client, {
+    terminal: terminalAddress,
+    holder,
+    projectId,
+    cashOutCount,
+    tokenToReclaim,
+    beneficiary,
+    metadata: "0x",
+  });
+  const route = await resolvePreview(preview);
+  let lockedPreview: CashOutPreviewSnapshot | null = null;
+
+  if (route.route === "amm") {
+    lockedPreview = await readCashOutPreviewSnapshot(client, {
+      terminal: terminalAddress,
+      holder,
+      projectId,
+      cashOutCount,
+      tokenToReclaim,
+      beneficiary,
+      metadata: route.metadata,
+    });
+    const lockedRoute = await resolvePreview(lockedPreview);
+    if (
+      (preview.rulesetId !== null &&
+        lockedPreview.rulesetId !== null &&
+        lockedPreview.rulesetId !== preview.rulesetId) ||
+      lockedRoute.route !== "amm" ||
+      lockedRoute.minimumReturn !== route.minimumReturn ||
+      lockedRoute.metadata.toLowerCase() !== route.metadata.toLowerCase()
+    ) {
+      throw new CashOutRouteChangedError();
+    }
+  }
+
+  return {
+    route,
+    transaction: buildCashOutTx({
+      chainId,
+      terminal: terminalAddress,
+      holder,
+      projectId,
+      cashOutCount,
+      tokenToReclaim,
+      minTokensReclaimed: route.terminalMinimum,
+      beneficiary,
+      metadata: route.metadata,
+    }),
+    preview,
+    lockedPreview,
+  };
+}
+
+/**
+ * Freshly prepare the best executable cash-out or direct-swap transaction.
+ *
+ * A direct swap is freshly quoted and slippage-floored in the same operation
+ * which builds its Universal Router request. If it cannot safely beat the
+ * terminal, the terminal path is re-previewed and locked instead.
+ */
+export async function prepareBestCashOut(
+  client: PublicClient,
+  args: BestCashOutArguments & { directSwapDeadline: bigint },
+): Promise<PreparedBestCashOut> {
+  const best = await getBestCashOutRoute(client, args);
+  if (best.kind === "direct-swap") {
+    return {
+      kind: "direct-swap",
+      route: best,
+      transaction: buildUniswapV4ExactInputSwapTx({
+        chainId: args.chainId,
+        poolKey: best.poolKey,
+        zeroForOne: best.zeroForOne,
+        amountIn: args.cashOutCount,
+        minimumAmountOut: best.minimumReturn,
+        recipient: args.beneficiary ?? args.holder,
+        deadline: args.directSwapDeadline,
+      }),
+    };
+  }
+
+  return {
+    kind: "cash-out",
+    ...(await prepareHookAwareCashOut(client, args)),
+  };
 }
 
 /**

--- a/packages/core/src/v6/uniswapV4.test.ts
+++ b/packages/core/src/v6/uniswapV4.test.ts
@@ -9,6 +9,7 @@ import {
 } from "viem";
 import type { PublicClient } from "viem";
 import { describe, expect, test } from "vitest";
+import { NATIVE_TOKEN } from "../constants.js";
 import {
   UNISWAP_V4_MAX_TICK,
   UNISWAP_V4_MODIFY_LIQUIDITY_TOPIC,
@@ -31,10 +32,15 @@ import {
   uniswapV4PoolStateSlot,
   uniswapV4PositionTicks,
   uniswapV4PositionTokenIdFromLog,
+  uniswapV4PriceAtTick,
   uniswapV4PriceFromSqrtPriceX96,
+  uniswapV4PriceRangeFromTicks,
   quoteUniswapV4ExactInputSingle,
   uniswapV4SqrtPriceX96AtTick,
   uniswapV4SqrtPriceX96FromSlot0,
+  uniswapV4SwapDirection,
+  uniswapV4TickAtPrice,
+  uniswapV4TickRangeFromPrices,
 } from "./uniswapV4.js";
 
 const TOKEN = "0x00000000000000000000000000000000000000aa" as const;
@@ -98,6 +104,30 @@ describe("Uniswap V4 direct swaps", () => {
     tickSpacing: 200,
     hooks: HOOK,
   } as const;
+
+  test("matches both sides of the pair and normalizes the native sentinel", () => {
+    expect(
+      uniswapV4SwapDirection({
+        poolKey: key,
+        tokenIn: NATIVE_TOKEN,
+        tokenOut: TOKEN,
+      }),
+    ).toBe(true);
+    expect(
+      uniswapV4SwapDirection({
+        poolKey: key,
+        tokenIn: TOKEN,
+        tokenOut: NATIVE_TOKEN,
+      }),
+    ).toBe(false);
+    expect(
+      uniswapV4SwapDirection({
+        poolKey: key,
+        tokenIn: TOKEN,
+        tokenOut: HOOK,
+      }),
+    ).toBeNull();
+  });
 
   test("builds a native exact-input Universal Router swap", () => {
     const tx = buildUniswapV4ExactInputSwapTx({
@@ -247,6 +277,48 @@ describe("Uniswap V4 tick and liquidity math", () => {
     expect(() => uniswapV4SqrtPriceX96AtTick(UNISWAP_V4_MAX_TICK + 1)).toThrow(
       /outside/,
     );
+  });
+
+  test("normalizes tick and price ranges for either currency ordering", () => {
+    const currency0LowTick = uniswapV4PriceAtTick(-600, true, 18);
+    const currency0HighTick = uniswapV4PriceAtTick(600, true, 18);
+    const currency1LowTick = uniswapV4PriceAtTick(-600, false, 18);
+    const currency1HighTick = uniswapV4PriceAtTick(600, false, 18);
+
+    expect(currency0LowTick).toBeGreaterThan(currency0HighTick!);
+    expect(currency1LowTick).toBeLessThan(currency1HighTick!);
+    expect(uniswapV4TickAtPrice(currency0HighTick!, true, 18)).toBeCloseTo(
+      600,
+      5,
+    );
+    expect(uniswapV4TickAtPrice(currency1HighTick!, false, 18)).toBeCloseTo(
+      600,
+      5,
+    );
+
+    for (const pairIsCurrency0 of [true, false]) {
+      const prices = uniswapV4PriceRangeFromTicks(
+        -600,
+        600,
+        pairIsCurrency0,
+        18,
+      );
+      expect(prices?.min).toBeLessThan(prices!.max);
+      const ticks = uniswapV4TickRangeFromPrices(
+        prices!.min,
+        prices!.max,
+        pairIsCurrency0,
+        18,
+      );
+      expect(ticks?.lower).toBeCloseTo(-600, 5);
+      expect(ticks?.upper).toBeCloseTo(600, 5);
+    }
+  });
+
+  test("rejects invalid human tick/price inputs", () => {
+    expect(uniswapV4PriceAtTick(1.5, true, 18)).toBeNull();
+    expect(uniswapV4TickAtPrice(0, true, 18)).toBeNull();
+    expect(uniswapV4TickRangeFromPrices(0, 1, true, 18)).toBeNull();
   });
 
   test("derived liquidity never consumes more than the supplied amounts", () => {

--- a/packages/core/src/v6/uniswapV4.ts
+++ b/packages/core/src/v6/uniswapV4.ts
@@ -7,6 +7,7 @@ import {
   zeroAddress,
 } from "viem";
 import type { Address, Hex, PublicClient } from "viem";
+import { NATIVE_TOKEN } from "../constants.js";
 import type { JBChainId } from "../types.js";
 
 /**
@@ -117,6 +118,38 @@ export interface UniswapV4PoolKey {
   fee: number;
   tickSpacing: number;
   hooks: Address;
+}
+
+function normalizeUniswapV4Currency(token: Address): string {
+  return token.toLowerCase() === NATIVE_TOKEN.toLowerCase()
+    ? zeroAddress
+    : token.toLowerCase();
+}
+
+/**
+ * Resolve the exact swap direction for a token pair, normalizing Juicebox's
+ * native-token sentinel to Uniswap V4's zero-address currency.
+ *
+ * Returns `null` unless both input and output match opposite sides of the pool.
+ * Clients should fail closed on `null` instead of inferring the output token
+ * from the input side alone.
+ */
+export function uniswapV4SwapDirection({
+  poolKey,
+  tokenIn,
+  tokenOut,
+}: {
+  poolKey: UniswapV4PoolKey;
+  tokenIn: Address;
+  tokenOut: Address;
+}): boolean | null {
+  const input = normalizeUniswapV4Currency(tokenIn);
+  const output = normalizeUniswapV4Currency(tokenOut);
+  const currency0 = poolKey.currency0.toLowerCase();
+  const currency1 = poolKey.currency1.toLowerCase();
+  if (input === currency0 && output === currency1) return true;
+  if (input === currency1 && output === currency0) return false;
+  return null;
 }
 
 const V4_QUOTER_ABI = [
@@ -442,6 +475,85 @@ export function uniswapV4PriceFromSqrtPriceX96(
   if (rawRatio === null) return null;
   const price = rawRatio * 10 ** (18 - pairTokenDecimals);
   return Number.isFinite(price) && price > 0 ? price : null;
+}
+
+/** Human pair-token price at a Uniswap V4 tick, in either currency ordering. */
+export function uniswapV4PriceAtTick(
+  tick: number,
+  pairIsCurrency0: boolean,
+  pairTokenDecimals: number,
+): number | null {
+  if (!Number.isInteger(tick)) return null;
+  return uniswapV4PriceFromSqrtPriceX96(
+    uniswapV4SqrtPriceX96AtTick(tick),
+    pairIsCurrency0,
+    pairTokenDecimals,
+  );
+}
+
+/** Inverse of {@link uniswapV4PriceAtTick}; returns a fractional raw tick. */
+export function uniswapV4TickAtPrice(
+  price: number,
+  pairIsCurrency0: boolean,
+  pairTokenDecimals: number,
+): number | null {
+  if (
+    !(price > 0) ||
+    !Number.isFinite(price) ||
+    !Number.isSafeInteger(pairTokenDecimals)
+  ) {
+    return null;
+  }
+  const decimalFactor = 10 ** (18 - pairTokenDecimals);
+  const rawRatio = pairIsCurrency0
+    ? decimalFactor / price
+    : price / decimalFactor;
+  const tick = Math.log(rawRatio) / Math.log(1.0001);
+  return Number.isFinite(tick) ? tick : null;
+}
+
+/** Map two ticks to an order-independent human-price range. */
+export function uniswapV4PriceRangeFromTicks(
+  tickA: number,
+  tickB: number,
+  pairIsCurrency0: boolean,
+  pairTokenDecimals: number,
+): { min: number; max: number } | null {
+  const priceA = uniswapV4PriceAtTick(
+    tickA,
+    pairIsCurrency0,
+    pairTokenDecimals,
+  );
+  const priceB = uniswapV4PriceAtTick(
+    tickB,
+    pairIsCurrency0,
+    pairTokenDecimals,
+  );
+  return priceA === null || priceB === null
+    ? null
+    : { min: Math.min(priceA, priceB), max: Math.max(priceA, priceB) };
+}
+
+/** Map two human prices to an order-independent raw-tick range. */
+export function uniswapV4TickRangeFromPrices(
+  priceA: number,
+  priceB: number,
+  pairIsCurrency0: boolean,
+  pairTokenDecimals: number,
+): { lower: number; upper: number } | null {
+  const tickA = uniswapV4TickAtPrice(
+    priceA,
+    pairIsCurrency0,
+    pairTokenDecimals,
+  );
+  const tickB = uniswapV4TickAtPrice(
+    priceB,
+    pairIsCurrency0,
+    pairTokenDecimals,
+  );
+  return tickA === null || tickB === null
+    ? null
+    : { lower: Math.min(tickA, tickB), upper: Math.max(tickA, tickB) };
 }
 
 /** Exact integer port of Uniswap V4 TickMath.getSqrtPriceAtTick. */


### PR DESCRIPTION
## What changed

- correct hook-aware cash-out floors to use the buyback hook’s executable quote instead of its optimistic raw quote
- add canonical terminal/direct-pool best-execution selection for claimed ERC-20 project tokens
- keep internal credits on the terminal path and fall back safely when pool discovery or quoting is unavailable
- prepare locked terminal cash-outs and direct Universal Router swaps from fresh protocol state
- expose typed cash-out error classification and pool-buffer diagnostics
- add exact Uniswap V4 pair-direction and price/tick orientation helpers

## Why

Clients independently rebuilt cash-out routing and slippage math. That duplicated a bug where an optimistic quote could become an impossible hard minimum, and it made it harder to route claimed tokens directly through a better pool while preserving the terminal path for credits. Centralizing these rules gives every web client the same executable quote, fallback behavior, and transaction preparation.

## User impact

Cash-outs use achievable slippage floors, known reverts can be explained consistently, and claimed project ERC-20s may be sold directly when their protected pool output strictly beats the full terminal preview. Pool failures never block an otherwise valid terminal cash-out.

## Validation

- `npm run type-check --workspace @bananapus/nana-sdk-core`
- `npm test --workspace @bananapus/nana-sdk-core -- src/v6/cashOut.test.ts src/v6/uniswapV4.test.ts` (47 tests)
- `npm run build --workspace @bananapus/nana-sdk-core`
- `git diff --check`