### PR TITLE
feat: add shared payment routing helpers

### DIFF
--- a/.changeset/smooth-payments.md
+++ b/.changeset/smooth-payments.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-core": minor
+---
+
+Add reusable four-mainnet cross-currency direct-pay routing, Permit2 signature and allowance helpers, and contract-exact loan opening proceeds.

--- a/packages/core/src/publicSurface.test.ts
+++ b/packages/core/src/publicSurface.test.ts
@@ -16,5 +16,9 @@ describe("published core SDK surfaces", () => {
     expect(sdk.bendystrawProjectRefsFilters).toBeTypeOf("function");
     expect(v6.buildDeployRevnetTx).toBeTypeOf("function");
     expect(v6.buildAutoIssueTx).toBeTypeOf("function");
+    expect(v6.quoteDirectPaySwap).toBeTypeOf("function");
+    expect(v6.buildDirectPaySwapTx).toBeTypeOf("function");
+    expect(v6.permit2TypedData).toBeTypeOf("function");
+    expect(v6.netLoanProceeds).toBeTypeOf("function");
   });
 });

--- a/packages/core/src/v6/directPay.test.ts
+++ b/packages/core/src/v6/directPay.test.ts
@@ -1,0 +1,380 @@
+import { decodeAbiParameters, encodeAbiParameters, zeroAddress } from "viem";
+import type { Address, Hex, PublicClient } from "viem";
+import { describe, expect, test } from "vitest";
+import { NATIVE_TOKEN } from "../constants.js";
+import {
+  NATIVE_SWAP_BY_CHAIN,
+  addPermit2SignatureToDirectPaySwap,
+  buildDirectPaySwapTx,
+  quoteDirectPaySwap,
+  type DirectPaySwapQuote,
+} from "./directPay.js";
+import type { Permit2SignatureAuthorization } from "./permit2.js";
+
+const PROJECT_TOKEN = "0x2222222222222222222222222222222222222222" as Address;
+const RECIPIENT = "0x3333333333333333333333333333333333333333" as Address;
+const HOOK = "0x4444444444444444444444444444444444444444" as Address;
+const SIGNATURE = `0x${"55".repeat(65)}` as Hex;
+const MAINNET_CHAIN_IDS = [1, 10, 8453, 42161] as const;
+
+function quoteClient({
+  v3Outputs = [70n, 90n, 80n, 60n],
+  v4Output = 200n,
+}: {
+  v3Outputs?: (bigint | null)[];
+  v4Output?: bigint;
+} = {}): PublicClient {
+  let v3Call = 0;
+  return {
+    call: async ({ to }: { to?: Address }) => {
+      if (
+        to?.toLowerCase() === NATIVE_SWAP_BY_CHAIN[8453]!.v3Quoter.toLowerCase()
+      ) {
+        const amountOut = v3Outputs[v3Call++];
+        if (amountOut === null || amountOut === undefined) {
+          throw new Error("pool missing");
+        }
+        return {
+          data: encodeAbiParameters(
+            [
+              { type: "uint256" },
+              { type: "uint160" },
+              { type: "uint32" },
+              { type: "uint256" },
+            ],
+            [amountOut, 0n, 0, 0n],
+          ),
+        };
+      }
+      return {
+        data: encodeAbiParameters(
+          [{ type: "uint256" }, { type: "uint256" }],
+          [v4Output, 0n],
+        ),
+      };
+    },
+  } as unknown as PublicClient;
+}
+
+function fixture(
+  inputRoute: DirectPaySwapQuote["inputRoute"] = { kind: "single-v4" },
+): DirectPaySwapQuote {
+  return {
+    kind: "direct-swap",
+    poolKey: {
+      currency0: NATIVE_SWAP_BY_CHAIN[8453]!.bridgeToken,
+      currency1: PROJECT_TOKEN,
+      fee: 10_000,
+      tickSpacing: 200,
+      hooks: HOOK,
+    },
+    zeroForOne: true,
+    quotedTokenCount: 101n,
+    minimumTokenCount: 100n,
+    beneficiaryTokenCount: 100n,
+    reservedTokenCount: 0n,
+    inputRoute,
+  };
+}
+
+describe("cross-currency direct-pay transactions", () => {
+  test("quotes direct and both bridged payment directions", async () => {
+    const base = NATIVE_SWAP_BY_CHAIN[8453]!;
+    const payPreview = {
+      beneficiaryTokenCount: 100n,
+      reservedTokenCount: 10n,
+    };
+    const direct = await quoteDirectPaySwap({
+      client: quoteClient(),
+      chainId: 8453,
+      poolKey: fixture().poolKey,
+      pairIsCurrency0: true,
+      paymentToken: base.bridgeToken,
+      amount: 25_000_000n,
+      payPreview,
+    });
+    expect(direct).toMatchObject({
+      kind: "direct-swap",
+      quotedTokenCount: 200n,
+      minimumTokenCount: 198n,
+      beneficiaryTokenCount: 198n,
+      reservedTokenCount: 0n,
+      inputRoute: { kind: "single-v4" },
+    });
+
+    const native = await quoteDirectPaySwap({
+      client: quoteClient(),
+      chainId: 8453,
+      poolKey: fixture().poolKey,
+      pairIsCurrency0: true,
+      paymentToken: NATIVE_TOKEN,
+      amount: 10n ** 16n,
+      payPreview,
+    });
+    expect(native?.inputRoute).toMatchObject({
+      kind: "native-v3-v4",
+      v3Fee: 500,
+      quotedBridgeAmount: 90n,
+    });
+
+    const usdcToNative = await quoteDirectPaySwap({
+      client: quoteClient(),
+      chainId: 8453,
+      poolKey: { ...fixture().poolKey, currency0: zeroAddress },
+      pairIsCurrency0: true,
+      paymentToken: base.bridgeToken,
+      amount: 25_000_000n,
+      payPreview,
+      paySettlement: "swap",
+    });
+    expect(usdcToNative?.inputRoute).toMatchObject({
+      kind: "erc20-v3-native-v4",
+      inputToken: base.bridgeToken,
+      v3Fee: 500,
+      quotedBridgeAmount: 90n,
+    });
+  });
+
+  test("fails closed when no executable direct route beats terminal pay", async () => {
+    const base = NATIVE_SWAP_BY_CHAIN[8453]!;
+    const common = {
+      client: quoteClient({ v4Output: 100n }),
+      chainId: 8453 as const,
+      poolKey: fixture().poolKey,
+      pairIsCurrency0: true,
+      paymentToken: base.bridgeToken,
+      payPreview: { beneficiaryTokenCount: 100n, reservedTokenCount: 0n },
+    };
+    await expect(
+      quoteDirectPaySwap({ ...common, amount: 25_000_000n }),
+    ).resolves.toBeNull();
+    await expect(
+      quoteDirectPaySwap({ ...common, amount: 0n }),
+    ).resolves.toBeNull();
+    await expect(
+      quoteDirectPaySwap({
+        ...common,
+        paymentToken: HOOK,
+        amount: 25_000_000n,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      quoteDirectPaySwap({
+        ...common,
+        client: quoteClient({ v3Outputs: [null, null, null, null] }),
+        paymentToken: NATIVE_TOKEN,
+        amount: 10n ** 16n,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  test("builds both bridge directions on every supported mainnet", () => {
+    for (const chainId of MAINNET_CHAIN_IDS) {
+      const config = NATIVE_SWAP_BY_CHAIN[chainId];
+      expect(
+        config,
+        `missing bridge config for chain ${chainId}`,
+      ).toBeDefined();
+      if (!config) continue;
+
+      const nativeRequest = buildDirectPaySwapTx({
+        chainId,
+        quote: {
+          ...fixture(),
+          poolKey: {
+            ...fixture().poolKey,
+            currency0: config.bridgeToken,
+          },
+          inputRoute: {
+            kind: "native-v3-v4",
+            wrappedNative: config.wrappedNative,
+            bridgeToken: config.bridgeToken,
+            bridgeTokenSymbol: "USDC",
+            bridgeTokenDecimals: 6,
+            v3Fee: 500,
+            quotedBridgeAmount: 25_000_000n,
+          },
+        },
+        amount: 10_000_000_000_000_000n,
+        recipient: RECIPIENT,
+        deadline: 1_800_000_000n,
+      });
+      expect(nativeRequest.chainId).toBe(chainId);
+      expect(nativeRequest.args[0]).toBe("0x0b0010");
+      expect(nativeRequest.value).toBe(10_000_000_000_000_000n);
+      const [nativeActions] = decodeAbiParameters(
+        [{ type: "bytes" }, { type: "bytes[]" }],
+        nativeRequest.args[1][2],
+      );
+      expect(nativeActions).toBe("0x0b060e");
+
+      const erc20Request = buildDirectPaySwapTx({
+        chainId,
+        quote: {
+          ...fixture(),
+          poolKey: {
+            ...fixture().poolKey,
+            currency0: zeroAddress,
+          },
+          inputRoute: {
+            kind: "erc20-v3-native-v4",
+            inputToken: config.bridgeToken,
+            wrappedNative: config.wrappedNative,
+            bridgeTokenSymbol: "ETH",
+            bridgeTokenDecimals: 18,
+            v3Fee: 500,
+            quotedBridgeAmount: 10_000_000_000_000_000n,
+          },
+        },
+        amount: 25_000_000n,
+        recipient: RECIPIENT,
+        deadline: 1_800_000_000n,
+      });
+      expect(erc20Request.chainId).toBe(chainId);
+      expect(erc20Request.args[0]).toBe("0x000c10");
+      expect(erc20Request.value).toBe(0n);
+      const [erc20Actions] = decodeAbiParameters(
+        [{ type: "bytes" }, { type: "bytes[]" }],
+        erc20Request.args[1][2],
+      );
+      expect(erc20Actions).toBe("0x0b060e");
+    }
+  });
+
+  test("prepends a PermitSingle to ERC-20 direct swaps", () => {
+    const request = buildDirectPaySwapTx({
+      chainId: 8453,
+      quote: fixture(),
+      amount: 25_000_000n,
+      recipient: RECIPIENT,
+      deadline: 1_800_000_000n,
+    });
+    const authorization: Permit2SignatureAuthorization = {
+      chainId: 8453,
+      token: NATIVE_SWAP_BY_CHAIN[8453]!.bridgeToken,
+      spender: request.address,
+      amount: 25_000_000n,
+      expiration: 1_799_999_900,
+      nonce: 7,
+      sigDeadline: 1_799_999_900n,
+    };
+    const signed = addPermit2SignatureToDirectPaySwap(
+      request,
+      authorization,
+      SIGNATURE,
+    );
+    expect(signed.args[0]).toBe("0x0a10");
+    expect(signed.args[1]).toHaveLength(2);
+    expect(signed.args[1][0].toLowerCase()).toContain(
+      SIGNATURE.slice(2).toLowerCase(),
+    );
+
+    expect(() =>
+      addPermit2SignatureToDirectPaySwap(
+        request,
+        { ...authorization, spender: zeroAddress },
+        SIGNATURE,
+      ),
+    ).toThrow(/does not match/);
+  });
+
+  test("rejects invalid bridge requests and non-ERC-20 permit shapes", () => {
+    const base = NATIVE_SWAP_BY_CHAIN[8453]!;
+    const nativeQuote: DirectPaySwapQuote = {
+      ...fixture(),
+      inputRoute: {
+        kind: "native-v3-v4",
+        wrappedNative: base.wrappedNative,
+        bridgeToken: base.bridgeToken,
+        bridgeTokenSymbol: "USDC",
+        bridgeTokenDecimals: 6,
+        v3Fee: 500,
+        quotedBridgeAmount: 25_000_000n,
+      },
+    };
+    expect(() =>
+      buildDirectPaySwapTx({
+        chainId: 8453,
+        quote: nativeQuote,
+        amount: 0n,
+        recipient: RECIPIENT,
+        deadline: 1n,
+      }),
+    ).toThrow(/outside the supported range/);
+    expect(() =>
+      buildDirectPaySwapTx({
+        chainId: 84532,
+        quote: nativeQuote,
+        amount: 1n,
+        recipient: RECIPIENT,
+        deadline: 1n,
+      }),
+    ).toThrow(/No supported native bridge route/);
+    expect(() =>
+      buildDirectPaySwapTx({
+        chainId: 8453,
+        quote: {
+          ...nativeQuote,
+          inputRoute: {
+            kind: "native-v3-v4",
+            wrappedNative: base.wrappedNative,
+            bridgeToken: HOOK,
+            bridgeTokenSymbol: "USDC",
+            bridgeTokenDecimals: 6,
+            v3Fee: 500,
+            quotedBridgeAmount: 25_000_000n,
+          },
+        },
+        amount: 1n,
+        recipient: RECIPIENT,
+        deadline: 1n,
+      }),
+    ).toThrow(/native bridge route is not supported/);
+
+    const erc20Quote: DirectPaySwapQuote = {
+      ...fixture(),
+      poolKey: { ...fixture().poolKey, currency0: zeroAddress },
+      inputRoute: {
+        kind: "erc20-v3-native-v4",
+        inputToken: HOOK,
+        wrappedNative: base.wrappedNative,
+        bridgeTokenSymbol: "ETH",
+        bridgeTokenDecimals: 18,
+        v3Fee: 500,
+        quotedBridgeAmount: 1n,
+      },
+    };
+    expect(() =>
+      buildDirectPaySwapTx({
+        chainId: 8453,
+        quote: erc20Quote,
+        amount: 1n,
+        recipient: RECIPIENT,
+        deadline: 1n,
+      }),
+    ).toThrow(/ERC-20 bridge route is not supported/);
+
+    const nativeRequest = buildDirectPaySwapTx({
+      chainId: 8453,
+      quote: nativeQuote,
+      amount: 1n,
+      recipient: RECIPIENT,
+      deadline: 1n,
+    });
+    expect(() =>
+      addPermit2SignatureToDirectPaySwap(
+        nativeRequest,
+        {
+          chainId: 8453,
+          token: NATIVE_TOKEN,
+          spender: nativeRequest.address,
+          amount: 1n,
+          expiration: 2,
+          nonce: 0,
+          sigDeadline: 2n,
+        },
+        SIGNATURE,
+      ),
+    ).toThrow(/unsupported Universal Router shape/);
+  });
+});

--- a/packages/core/src/v6/directPay.ts
+++ b/packages/core/src/v6/directPay.ts
@@ -1,0 +1,560 @@
+import {
+  decodeFunctionResult,
+  encodeAbiParameters,
+  encodeFunctionData,
+  encodePacked,
+  zeroAddress,
+} from "viem";
+import type { Address, Hex, PublicClient } from "viem";
+import { NATIVE_TOKEN } from "../constants.js";
+import type { JBChainId } from "../types.js";
+import {
+  chooseBestPayRoute,
+  type PayPreview,
+  type PaySettlement,
+} from "./pay.js";
+import type { Permit2SignatureAuthorization } from "./permit2.js";
+import {
+  buildUniswapV4ExactInputSwapTx,
+  quoteUniswapV4ExactInputSingle,
+  uniswapV4Deployment,
+  type UniswapV4PoolKey,
+} from "./uniswapV4.js";
+
+export interface NativeSwapConfig {
+  wrappedNative: Address;
+  bridgeToken: Address;
+  v3Quoter: Address;
+}
+
+/** Canonical WETH/USDC V3 bridge used by direct-pay swaps on all v6 mainnets. */
+export const NATIVE_SWAP_BY_CHAIN: Readonly<
+  Partial<Record<JBChainId, NativeSwapConfig>>
+> = {
+  1: {
+    wrappedNative: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    bridgeToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    v3Quoter: "0x61fFE014bA17989E743c5F6cB21bF9697530B21e",
+  },
+  10: {
+    wrappedNative: "0x4200000000000000000000000000000000000006",
+    bridgeToken: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+    v3Quoter: "0x61fFE014bA17989E743c5F6cB21bF9697530B21e",
+  },
+  8453: {
+    wrappedNative: "0x4200000000000000000000000000000000000006",
+    bridgeToken: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    v3Quoter: "0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a",
+  },
+  42161: {
+    wrappedNative: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+    bridgeToken: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    v3Quoter: "0x61fFE014bA17989E743c5F6cB21bF9697530B21e",
+  },
+};
+
+const V3_FEES = [100, 500, 3_000, 10_000] as const;
+const ADDRESS_THIS = "0x0000000000000000000000000000000000000002" as Address;
+const CONTRACT_BALANCE = 1n << 255n;
+const UINT128_MAX = (1n << 128n) - 1n;
+
+const v3QuoterAbi = [
+  {
+    type: "function",
+    name: "quoteExactInputSingle",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "params",
+        type: "tuple",
+        components: [
+          { name: "tokenIn", type: "address" },
+          { name: "tokenOut", type: "address" },
+          { name: "amountIn", type: "uint256" },
+          { name: "fee", type: "uint24" },
+          { name: "sqrtPriceLimitX96", type: "uint160" },
+        ],
+      },
+    ],
+    outputs: [
+      { name: "amountOut", type: "uint256" },
+      { name: "sqrtPriceX96After", type: "uint160" },
+      { name: "initializedTicksCrossed", type: "uint32" },
+      { name: "gasEstimate", type: "uint256" },
+    ],
+  },
+] as const;
+
+const universalRouterAbi = [
+  {
+    type: "function",
+    name: "execute",
+    stateMutability: "payable",
+    inputs: [
+      { name: "commands", type: "bytes" },
+      { name: "inputs", type: "bytes[]" },
+      { name: "deadline", type: "uint256" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+export type DirectPayInputRoute =
+  | { kind: "single-v4" }
+  | {
+      kind: "native-v3-v4";
+      wrappedNative: Address;
+      bridgeToken: Address;
+      bridgeTokenSymbol: "USDC";
+      bridgeTokenDecimals: 6;
+      v3Fee: number;
+      quotedBridgeAmount: bigint;
+    }
+  | {
+      kind: "erc20-v3-native-v4";
+      inputToken: Address;
+      wrappedNative: Address;
+      bridgeTokenSymbol: "ETH";
+      bridgeTokenDecimals: 18;
+      v3Fee: number;
+      quotedBridgeAmount: bigint;
+    };
+
+export interface DirectPaySwapQuote {
+  kind: "direct-swap";
+  poolKey: UniswapV4PoolKey;
+  zeroForOne: boolean;
+  quotedTokenCount: bigint;
+  /** Protected minimum and the beneficiary's direct-swap token count. */
+  minimumTokenCount: bigint;
+  beneficiaryTokenCount: bigint;
+  reservedTokenCount: 0n;
+  inputRoute: DirectPayInputRoute;
+}
+
+function isNative(token: Address): boolean {
+  return token.toLowerCase() === NATIVE_TOKEN.toLowerCase();
+}
+
+async function quoteV3ExactInput({
+  client,
+  config,
+  tokenIn,
+  tokenOut,
+  amountIn,
+}: {
+  client: PublicClient;
+  config: NativeSwapConfig;
+  tokenIn: Address;
+  tokenOut: Address;
+  amountIn: bigint;
+}): Promise<{ fee: number; amountOut: bigint } | null> {
+  const quotes = await Promise.all(
+    V3_FEES.map(async (fee) => {
+      try {
+        const call = await client.call({
+          to: config.v3Quoter,
+          data: encodeFunctionData({
+            abi: v3QuoterAbi,
+            functionName: "quoteExactInputSingle",
+            args: [
+              {
+                tokenIn,
+                tokenOut,
+                amountIn,
+                fee,
+                sqrtPriceLimitX96: 0n,
+              },
+            ],
+          }),
+        });
+        if (!call.data) return null;
+        const [amountOut] = decodeFunctionResult({
+          abi: v3QuoterAbi,
+          functionName: "quoteExactInputSingle",
+          data: call.data,
+        });
+        return amountOut > 0n ? { fee, amountOut } : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return quotes.reduce<{ fee: number; amountOut: bigint } | null>(
+    (best, quote) =>
+      !quote || (best && best.amountOut >= quote.amountOut) ? best : quote,
+    null,
+  );
+}
+
+/**
+ * Quote the best direct pool purchase, including the atomic ETH/USDC V3 bridge
+ * when the user's payment currency differs from the hooked V4 pool currency.
+ * Returns null unless its slippage-protected minimum beats terminal payment.
+ */
+export async function quoteDirectPaySwap({
+  client,
+  chainId,
+  poolKey,
+  pairIsCurrency0,
+  paymentToken,
+  amount,
+  payPreview,
+  paySettlement = "issuance",
+  slippageBps = 100n,
+}: {
+  client: PublicClient;
+  chainId: JBChainId;
+  poolKey: UniswapV4PoolKey;
+  pairIsCurrency0: boolean;
+  paymentToken: Address;
+  amount: bigint;
+  payPreview: PayPreview;
+  paySettlement?: PaySettlement;
+  slippageBps?: bigint;
+}): Promise<DirectPaySwapQuote | null> {
+  if (!uniswapV4Deployment(chainId)?.universalRouter || amount <= 0n) {
+    return null;
+  }
+  const currencyIn = pairIsCurrency0 ? poolKey.currency0 : poolKey.currency1;
+  const normalizedPayment = isNative(paymentToken)
+    ? zeroAddress
+    : paymentToken.toLowerCase();
+  let v4AmountIn = amount;
+  let inputRoute: DirectPayInputRoute = { kind: "single-v4" };
+
+  if (currencyIn.toLowerCase() !== normalizedPayment) {
+    const config = NATIVE_SWAP_BY_CHAIN[chainId];
+    const canBridgeNative =
+      !!config &&
+      isNative(paymentToken) &&
+      currencyIn.toLowerCase() === config.bridgeToken.toLowerCase();
+    const canBridgeUsdcToNative =
+      !!config &&
+      paymentToken.toLowerCase() === config.bridgeToken.toLowerCase() &&
+      currencyIn.toLowerCase() === zeroAddress;
+    if (!config || (!canBridgeNative && !canBridgeUsdcToNative)) return null;
+    const bridgeQuote = await quoteV3ExactInput({
+      client,
+      config,
+      tokenIn: canBridgeNative ? config.wrappedNative : config.bridgeToken,
+      tokenOut: canBridgeNative ? config.bridgeToken : config.wrappedNative,
+      amountIn: amount,
+    });
+    if (!bridgeQuote) return null;
+    v4AmountIn = bridgeQuote.amountOut;
+    inputRoute = canBridgeNative
+      ? {
+          kind: "native-v3-v4",
+          wrappedNative: config.wrappedNative,
+          bridgeToken: config.bridgeToken,
+          bridgeTokenSymbol: "USDC",
+          bridgeTokenDecimals: 6,
+          v3Fee: bridgeQuote.fee,
+          quotedBridgeAmount: bridgeQuote.amountOut,
+        }
+      : {
+          kind: "erc20-v3-native-v4",
+          inputToken: config.bridgeToken,
+          wrappedNative: config.wrappedNative,
+          bridgeTokenSymbol: "ETH",
+          bridgeTokenDecimals: 18,
+          v3Fee: bridgeQuote.fee,
+          quotedBridgeAmount: bridgeQuote.amountOut,
+        };
+  }
+
+  const quotedTokenCount = await quoteUniswapV4ExactInputSingle(client, {
+    chainId,
+    poolKey,
+    zeroForOne: pairIsCurrency0,
+    amountIn: v4AmountIn,
+  });
+  const best = chooseBestPayRoute({
+    pay: payPreview,
+    paySettlement,
+    directSwapQuote: quotedTokenCount,
+    slippageBps,
+  });
+  if (best.kind !== "direct-swap") return null;
+  return {
+    kind: "direct-swap",
+    poolKey,
+    zeroForOne: pairIsCurrency0,
+    quotedTokenCount,
+    minimumTokenCount: best.beneficiaryTokenCount,
+    beneficiaryTokenCount: best.beneficiaryTokenCount,
+    reservedTokenCount: 0n,
+    inputRoute,
+  };
+}
+
+function encodeV4SwapFromRouterBalance({
+  quote,
+  recipient,
+  currencyIn,
+}: {
+  quote: DirectPaySwapQuote;
+  recipient: Address;
+  currencyIn: Address;
+}): Hex {
+  const swap = encodeAbiParameters(
+    [
+      {
+        type: "tuple",
+        components: [
+          {
+            type: "tuple",
+            components: [
+              { type: "address" },
+              { type: "address" },
+              { type: "uint24" },
+              { type: "int24" },
+              { type: "address" },
+            ],
+          },
+          { type: "bool" },
+          { type: "uint128" },
+          { type: "uint128" },
+          { type: "bytes" },
+        ],
+      },
+    ],
+    [
+      [
+        [
+          quote.poolKey.currency0,
+          quote.poolKey.currency1,
+          quote.poolKey.fee,
+          quote.poolKey.tickSpacing,
+          quote.poolKey.hooks,
+        ],
+        quote.zeroForOne,
+        0n,
+        quote.minimumTokenCount,
+        "0x",
+      ],
+    ],
+  );
+  const settle = encodeAbiParameters(
+    [{ type: "address" }, { type: "uint256" }, { type: "bool" }],
+    [currencyIn, CONTRACT_BALANCE, false],
+  );
+  const currencyOut = quote.zeroForOne
+    ? quote.poolKey.currency1
+    : quote.poolKey.currency0;
+  const take = encodeAbiParameters(
+    [{ type: "address" }, { type: "address" }, { type: "uint256" }],
+    [currencyOut, recipient, 0n],
+  );
+  return encodeAbiParameters(
+    [{ type: "bytes" }, { type: "bytes[]" }],
+    ["0x0b060e", [settle, swap, take]],
+  );
+}
+
+/** Build the atomic Universal Router transaction for a direct-pay quote. */
+export function buildDirectPaySwapTx({
+  chainId,
+  quote,
+  amount,
+  recipient,
+  deadline,
+}: {
+  chainId: JBChainId;
+  quote: DirectPaySwapQuote;
+  amount: bigint;
+  recipient: Address;
+  deadline: bigint;
+}) {
+  if (quote.inputRoute.kind === "single-v4") {
+    return buildUniswapV4ExactInputSwapTx({
+      chainId,
+      poolKey: quote.poolKey,
+      zeroForOne: quote.zeroForOne,
+      amountIn: amount,
+      minimumAmountOut: quote.minimumTokenCount,
+      recipient,
+      deadline,
+    });
+  }
+  if (amount <= 0n || amount > UINT128_MAX || quote.minimumTokenCount <= 0n) {
+    throw new Error("Swap amounts are outside the supported range.");
+  }
+  const config = NATIVE_SWAP_BY_CHAIN[chainId];
+  const router = uniswapV4Deployment(chainId)?.universalRouter;
+  if (!config || !router) {
+    throw new Error("No supported native bridge route on this chain.");
+  }
+
+  if (quote.inputRoute.kind === "erc20-v3-native-v4") {
+    if (
+      quote.inputRoute.inputToken.toLowerCase() !==
+        config.bridgeToken.toLowerCase() ||
+      quote.inputRoute.wrappedNative.toLowerCase() !==
+        config.wrappedNative.toLowerCase()
+    ) {
+      throw new Error(
+        "This ERC-20 bridge route is not supported on this chain.",
+      );
+    }
+    const v3Input = encodeAbiParameters(
+      [
+        { type: "address" },
+        { type: "uint256" },
+        { type: "uint256" },
+        { type: "bytes" },
+        { type: "bool" },
+      ],
+      [
+        ADDRESS_THIS,
+        amount,
+        0n,
+        encodePacked(
+          ["address", "uint24", "address"],
+          [
+            quote.inputRoute.inputToken,
+            quote.inputRoute.v3Fee,
+            quote.inputRoute.wrappedNative,
+          ],
+        ),
+        true,
+      ],
+    );
+    const unwrapInput = encodeAbiParameters(
+      [{ type: "address" }, { type: "uint256" }],
+      [ADDRESS_THIS, 0n],
+    );
+    const v4Input = encodeV4SwapFromRouterBalance({
+      quote,
+      recipient,
+      currencyIn: zeroAddress,
+    });
+    return {
+      chainId,
+      address: router,
+      abi: universalRouterAbi,
+      functionName: "execute" as const,
+      args: [
+        "0x000c10" as Hex,
+        [v3Input, unwrapInput, v4Input],
+        deadline,
+      ] as const,
+      value: 0n,
+    };
+  }
+
+  if (
+    quote.inputRoute.bridgeToken.toLowerCase() !==
+      config.bridgeToken.toLowerCase() ||
+    quote.inputRoute.wrappedNative.toLowerCase() !==
+      config.wrappedNative.toLowerCase()
+  ) {
+    throw new Error("This native bridge route is not supported on this chain.");
+  }
+  const wrapInput = encodeAbiParameters(
+    [{ type: "address" }, { type: "uint256" }],
+    [ADDRESS_THIS, amount],
+  );
+  const v3Input = encodeAbiParameters(
+    [
+      { type: "address" },
+      { type: "uint256" },
+      { type: "uint256" },
+      { type: "bytes" },
+      { type: "bool" },
+    ],
+    [
+      ADDRESS_THIS,
+      amount,
+      0n,
+      encodePacked(
+        ["address", "uint24", "address"],
+        [
+          quote.inputRoute.wrappedNative,
+          quote.inputRoute.v3Fee,
+          quote.inputRoute.bridgeToken,
+        ],
+      ),
+      false,
+    ],
+  );
+  const v4Input = encodeV4SwapFromRouterBalance({
+    quote,
+    recipient,
+    currencyIn: quote.inputRoute.bridgeToken,
+  });
+  return {
+    chainId,
+    address: router,
+    abi: universalRouterAbi,
+    functionName: "execute" as const,
+    args: ["0x0b0010" as Hex, [wrapInput, v3Input, v4Input], deadline] as const,
+    value: amount,
+  };
+}
+
+/** Prepend Universal Router's PERMIT2_PERMIT command to a reviewed swap. */
+export function addPermit2SignatureToDirectPaySwap(
+  request: ReturnType<typeof buildDirectPaySwapTx>,
+  authorization: Permit2SignatureAuthorization,
+  signature: Hex,
+): ReturnType<typeof buildDirectPaySwapTx> {
+  if (request.address.toLowerCase() !== authorization.spender.toLowerCase()) {
+    throw new Error(
+      "The reviewed Permit2 authorization does not match the swap.",
+    );
+  }
+  const [commands, inputs, deadline] = request.args;
+  const commandShape = commands.toLowerCase();
+  const supportedShape =
+    (commandShape === "0x10" && inputs.length === 1) ||
+    (commandShape === "0x000c10" && inputs.length === 3);
+  if (!supportedShape) {
+    throw new Error(
+      "The reviewed swap has an unsupported Universal Router shape.",
+    );
+  }
+  const permitInput = encodeAbiParameters(
+    [
+      {
+        type: "tuple",
+        components: [
+          {
+            type: "tuple",
+            components: [
+              { type: "address" },
+              { type: "uint160" },
+              { type: "uint48" },
+              { type: "uint48" },
+            ],
+          },
+          { type: "address" },
+          { type: "uint256" },
+        ],
+      },
+      { type: "bytes" },
+    ],
+    [
+      [
+        [
+          authorization.token,
+          authorization.amount,
+          authorization.expiration,
+          authorization.nonce,
+        ],
+        authorization.spender,
+        authorization.sigDeadline,
+      ],
+      signature,
+    ],
+  );
+  return {
+    ...request,
+    args: [
+      `0x0a${commands.slice(2)}` as Hex,
+      [permitInput, ...inputs],
+      deadline,
+    ],
+  } as ReturnType<typeof buildDirectPaySwapTx>;
+}

--- a/packages/core/src/v6/index.ts
+++ b/packages/core/src/v6/index.ts
@@ -8,6 +8,8 @@ export * from "./splits.js";
 export * from "./revnets.js";
 export * from "./terminals.js";
 export * from "./pay.js";
+export * from "./directPay.js";
+export * from "./permit2.js";
 export * from "./projectPayers.js";
 export * from "./cashOut.js";
 export * from "./nft.js";

--- a/packages/core/src/v6/loans.test.ts
+++ b/packages/core/src/v6/loans.test.ts
@@ -5,12 +5,15 @@ import {
   EMPTY_SINGLE_ALLOWANCE,
   LOANS_MAX_FEE,
   MIN_PREPAID_FEE_PERCENT,
+  MAX_PREPAID_FEE_PERCENT,
   REVLOANS_PERMISSION_ID,
   REV_PREPAID_FEE_PERCENT,
   buildBorrowTx,
   buildReallocateCollateralTx,
   buildRepayLoanTx,
   getBorrowableAmount,
+  loanOpeningAmounts,
+  netLoanProceeds,
 } from "./loans.js";
 import { v6Address } from "./types.js";
 
@@ -21,9 +24,44 @@ const holder = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8" as const;
 describe("loans", () => {
   test("constants match REVLoans", () => {
     expect(MIN_PREPAID_FEE_PERCENT).toEqual(25n);
+    expect(MAX_PREPAID_FEE_PERCENT).toEqual(500n);
     expect(REV_PREPAID_FEE_PERCENT).toEqual(10n);
     expect(LOANS_MAX_FEE).toEqual(1000n);
     expect(REVLOANS_PERMISSION_ID).toEqual(1);
+  });
+
+  describe("loan opening fees", () => {
+    test("matches contract floor rounding at the minimum source fee", () => {
+      expect(loanOpeningAmounts({ grossBorrowAmount: 384_045_300n })).toEqual({
+        grossBorrowAmount: 384_045_300n,
+        protocolFee: 9_601_132n,
+        revFee: 3_840_453n,
+        sourceFee: 9_601_132n,
+        netBorrowAmount: 361_002_583n,
+      });
+      expect(netLoanProceeds(384_045_300n)).toBe(361_002_583n);
+    });
+
+    test("supports feeless beneficiaries and enforces REVLoans bounds", () => {
+      expect(
+        loanOpeningAmounts({
+          grossBorrowAmount: 1_000n,
+          protocolFeeApplies: false,
+          revFeeApplies: false,
+        }),
+      ).toMatchObject({
+        protocolFee: 0n,
+        revFee: 0n,
+        sourceFee: 25n,
+        netBorrowAmount: 975n,
+      });
+      expect(() =>
+        loanOpeningAmounts({
+          grossBorrowAmount: 1_000n,
+          prepaidSourceFeePercent: 24n,
+        }),
+      ).toThrow(/between 25 and 500/);
+    });
   });
 
   describe("buildBorrowTx", () => {
@@ -143,7 +181,7 @@ describe("loans", () => {
           address: v6Address("REVLoans", 11155111),
           functionName: "borrowableAmountFrom",
           args: [4n, 100n, 18n, 1n],
-        })
+        }),
       );
       expect(result).toEqual({
         borrowableNow: 111n,

--- a/packages/core/src/v6/loans.ts
+++ b/packages/core/src/v6/loans.ts
@@ -17,11 +17,80 @@ export const LOANS_MAX_FEE = 1000n;
  */
 export const MIN_PREPAID_FEE_PERCENT = 25n;
 
+/** The largest prepaid source fee REVLoans accepts: 500 / 1000 = 50%. */
+export const MAX_PREPAID_FEE_PERCENT = 500n;
+
 /**
  * The upfront fee REVLoans routes to the $REV revnet on every borrow: 10 of
  * {@link LOANS_MAX_FEE} (1%), taken in addition to the prepaid fee.
  */
 export const REV_PREPAID_FEE_PERCENT = 10n;
+
+export interface LoanOpeningAmounts {
+  grossBorrowAmount: bigint;
+  protocolFee: bigint;
+  revFee: bigint;
+  sourceFee: bigint;
+  netBorrowAmount: bigint;
+}
+
+/**
+ * Calculate a borrower's spendable proceeds using the same floor-rounded fee
+ * arithmetic as REVLoans, JBMultiTerminal, and JBFees.
+ *
+ * `grossBorrowAmount` is the principal recorded on the loan. The terminal's
+ * standard 2.5% allowance fee is deducted first, followed by REVLoans' 1% REV
+ * fee and the selected prepaid source fee (2.5% minimum).
+ */
+export function loanOpeningAmounts({
+  grossBorrowAmount,
+  prepaidSourceFeePercent = MIN_PREPAID_FEE_PERCENT,
+  protocolFeeApplies = true,
+  revFeeApplies = true,
+}: {
+  grossBorrowAmount: bigint;
+  prepaidSourceFeePercent?: bigint;
+  protocolFeeApplies?: boolean;
+  revFeeApplies?: boolean;
+}): LoanOpeningAmounts {
+  if (grossBorrowAmount < 0n) {
+    throw new Error("grossBorrowAmount cannot be negative.");
+  }
+  if (
+    prepaidSourceFeePercent < MIN_PREPAID_FEE_PERCENT ||
+    prepaidSourceFeePercent > MAX_PREPAID_FEE_PERCENT
+  ) {
+    throw new Error(
+      `prepaidSourceFeePercent must be between ${MIN_PREPAID_FEE_PERCENT} and ${MAX_PREPAID_FEE_PERCENT}.`,
+    );
+  }
+  const protocolFee = protocolFeeApplies ? grossBorrowAmount / 40n : 0n;
+  const revFee = revFeeApplies
+    ? (grossBorrowAmount * REV_PREPAID_FEE_PERCENT) / LOANS_MAX_FEE
+    : 0n;
+  const sourceFee =
+    (grossBorrowAmount * prepaidSourceFeePercent) / LOANS_MAX_FEE;
+  const totalFees = protocolFee + revFee + sourceFee;
+  return {
+    grossBorrowAmount,
+    protocolFee,
+    revFee,
+    sourceFee,
+    netBorrowAmount:
+      grossBorrowAmount > totalFees ? grossBorrowAmount - totalFees : 0n,
+  };
+}
+
+/** Convenience accessor for {@link loanOpeningAmounts}. */
+export function netLoanProceeds(
+  grossBorrowAmount: bigint,
+  prepaidSourceFeePercent = MIN_PREPAID_FEE_PERCENT,
+): bigint {
+  return loanOpeningAmounts({
+    grossBorrowAmount,
+    prepaidSourceFeePercent,
+  }).netBorrowAmount;
+}
 
 /**
  * The JBPermissions permission id apps grant to the REVLoans contract before borrowing
@@ -267,7 +336,7 @@ export async function getBorrowableAmount(
     collateralCount: bigint;
     decimals: bigint;
     currency: bigint;
-  }
+  },
 ): Promise<{ borrowableNow: bigint; borrowableCapacity: bigint }> {
   const [borrowableNow, borrowableCapacity] = await client.readContract({
     address: v6Address("REVLoans", chainId),

--- a/packages/core/src/v6/permit2.test.ts
+++ b/packages/core/src/v6/permit2.test.ts
@@ -1,0 +1,98 @@
+import type { Hex, PublicClient } from "viem";
+import { describe, expect, test, vi } from "vitest";
+import {
+  PERMIT2_ADDRESS,
+  needsPermit2Approval,
+  permit2AllowanceNeedsRefresh,
+  permit2SignatureNeedsOnchainFallback,
+  permit2TypedData,
+  readPermit2Allowance,
+  shouldUsePermit2Signature,
+} from "./permit2.js";
+import { UNISWAP_V4_UNIVERSAL_ROUTER_ADDRESSES } from "./uniswapV4.js";
+
+const OWNER = "0x1111111111111111111111111111111111111111" as const;
+const TOKEN = "0x2222222222222222222222222222222222222222" as const;
+
+describe("Permit2 helpers", () => {
+  test("builds canonical PermitSingle typed data", () => {
+    const typedData = permit2TypedData({
+      chainId: 8453,
+      token: TOKEN,
+      spender: UNISWAP_V4_UNIVERSAL_ROUTER_ADDRESSES[8453]!,
+      amount: 25_000_000n,
+      expiration: 2_000_000_000,
+      nonce: 7,
+      sigDeadline: 2_000_000_000n,
+    });
+    expect(typedData.domain.verifyingContract).toBe(PERMIT2_ADDRESS);
+    expect(typedData.primaryType).toBe("PermitSingle");
+    expect(typedData.message.details.nonce).toBe(7);
+  });
+
+  test("reads allowance and applies amount and expiration safety", async () => {
+    const readContract = vi
+      .fn()
+      .mockResolvedValue([30_000_000n, 2_000_000_000, 9]);
+    const client = { readContract } as unknown as PublicClient;
+    await expect(
+      readPermit2Allowance(client, {
+        chainId: 8453,
+        owner: OWNER,
+        token: TOKEN,
+      }),
+    ).resolves.toEqual({
+      amount: 30_000_000n,
+      expiration: 2_000_000_000,
+      nonce: 9,
+    });
+    await expect(
+      needsPermit2Approval({
+        client,
+        chainId: 8453,
+        owner: OWNER,
+        token: TOKEN,
+        amount: 25_000_000n,
+        now: 1_900_000_000,
+      }),
+    ).resolves.toBe(false);
+    expect(
+      permit2AllowanceNeedsRefresh({
+        allowance: { amount: 1n, expiration: 2_000_000_000 },
+        amount: 2n,
+        now: 1_900_000_000,
+      }),
+    ).toBe(true);
+  });
+
+  test("uses signatures for EOAs and never falls back after rejection", () => {
+    expect(
+      shouldUsePermit2Signature({
+        needsApproval: true,
+        walletLookupSettled: true,
+        walletBytecode: "0x" as Hex,
+        isSafe: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldUsePermit2Signature({
+        needsApproval: true,
+        walletLookupSettled: true,
+        walletBytecode: "0x1234",
+        isSafe: false,
+      }),
+    ).toBe(false);
+    expect(
+      permit2SignatureNeedsOnchainFallback({
+        code: 4001,
+        message: "User rejected the request",
+      }),
+    ).toBe(false);
+    expect(
+      permit2SignatureNeedsOnchainFallback({
+        code: -32602,
+        message: "Invalid parameters",
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/v6/permit2.ts
+++ b/packages/core/src/v6/permit2.ts
@@ -1,0 +1,214 @@
+import type { Address, Hex, PublicClient } from "viem";
+import { NATIVE_TOKEN } from "../constants.js";
+import type { JBChainId } from "../types.js";
+import { UNISWAP_PERMIT2_ADDRESS, uniswapV4Deployment } from "./uniswapV4.js";
+
+/** Canonical Permit2 deployment shared by supported EVM chains. */
+export const PERMIT2_ADDRESS = UNISWAP_PERMIT2_ADDRESS;
+
+/** Permit2 methods used to inspect or establish Universal Router allowances. */
+export const permit2Abi = [
+  {
+    type: "function",
+    name: "allowance",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "token", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [
+      { name: "amount", type: "uint160" },
+      { name: "expiration", type: "uint48" },
+      { name: "nonce", type: "uint48" },
+    ],
+  },
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint160" },
+      { name: "expiration", type: "uint48" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+/** EIP-712 types for Permit2's one-token, one-spender authorization. */
+export const PERMIT2_TYPES = {
+  PermitDetails: [
+    { name: "token", type: "address" },
+    { name: "amount", type: "uint160" },
+    { name: "expiration", type: "uint48" },
+    { name: "nonce", type: "uint48" },
+  ],
+  PermitSingle: [
+    { name: "details", type: "PermitDetails" },
+    { name: "spender", type: "address" },
+    { name: "sigDeadline", type: "uint256" },
+  ],
+} as const;
+
+export interface Permit2SignatureAuthorization {
+  chainId: JBChainId;
+  token: Address;
+  spender: Address;
+  amount: bigint;
+  expiration: number;
+  nonce: number;
+  sigDeadline: bigint;
+}
+
+export interface Permit2Allowance {
+  amount: bigint;
+  expiration: number;
+  nonce: number;
+}
+
+/** Build the exact typed-data payload a wallet signs for PermitSingle. */
+export function permit2TypedData(authorization: Permit2SignatureAuthorization) {
+  return {
+    domain: {
+      name: "Permit2" as const,
+      chainId: authorization.chainId,
+      verifyingContract: PERMIT2_ADDRESS,
+    },
+    types: PERMIT2_TYPES,
+    primaryType: "PermitSingle" as const,
+    message: {
+      details: {
+        token: authorization.token,
+        amount: authorization.amount,
+        expiration: authorization.expiration,
+        nonce: authorization.nonce,
+      },
+      spender: authorization.spender,
+      sigDeadline: authorization.sigDeadline,
+    },
+  };
+}
+
+/** Read an owner's Permit2 allowance, defaulting the spender to Universal Router. */
+export async function readPermit2Allowance(
+  client: PublicClient,
+  {
+    chainId,
+    owner,
+    token,
+    spender,
+  }: {
+    chainId: JBChainId;
+    owner: Address;
+    token: Address;
+    spender?: Address;
+  },
+): Promise<Permit2Allowance> {
+  const resolvedSpender =
+    spender ?? uniswapV4Deployment(chainId)?.universalRouter;
+  if (!resolvedSpender) {
+    throw new Error(
+      `No supported Uniswap Universal Router on chain ${chainId}.`,
+    );
+  }
+  const [amount, expiration, nonce] = await client.readContract({
+    address: PERMIT2_ADDRESS,
+    abi: permit2Abi,
+    functionName: "allowance",
+    args: [owner, token, resolvedSpender],
+  });
+  return { amount, expiration, nonce };
+}
+
+/** Whether an allowance is too small or expires inside the safety buffer. */
+export function permit2AllowanceNeedsRefresh({
+  allowance,
+  amount,
+  now = Math.floor(Date.now() / 1000),
+  expirationBufferSeconds = 1_800,
+}: {
+  allowance: Pick<Permit2Allowance, "amount" | "expiration">;
+  amount: bigint;
+  now?: number;
+  expirationBufferSeconds?: number;
+}): boolean {
+  if (expirationBufferSeconds < 0) {
+    throw new Error("expirationBufferSeconds cannot be negative.");
+  }
+  return (
+    allowance.amount < amount ||
+    allowance.expiration <= now + expirationBufferSeconds
+  );
+}
+
+/** Read whether an ERC-20 needs a fresh Permit2 authorization for Universal Router. */
+export async function needsPermit2Approval({
+  client,
+  chainId,
+  owner,
+  token,
+  amount,
+  now,
+  expirationBufferSeconds,
+}: {
+  client: PublicClient;
+  chainId: JBChainId;
+  owner: Address;
+  token: Address;
+  amount: bigint;
+  now?: number;
+  expirationBufferSeconds?: number;
+}): Promise<boolean> {
+  if (token.toLowerCase() === NATIVE_TOKEN.toLowerCase()) return false;
+  const allowance = await readPermit2Allowance(client, {
+    chainId,
+    owner,
+    token,
+  });
+  return permit2AllowanceNeedsRefresh({
+    allowance,
+    amount,
+    now,
+    expirationBufferSeconds,
+  });
+}
+
+/**
+ * Prefer a gasless Permit2 signature for EOAs. Contract wallets generally need
+ * the on-chain Permit2 approval path unless their integration handles ERC-1271.
+ */
+export function shouldUsePermit2Signature({
+  needsApproval,
+  walletLookupSettled,
+  walletBytecode,
+  isSafe,
+}: {
+  needsApproval: boolean;
+  walletLookupSettled: boolean;
+  walletBytecode?: Hex;
+  isSafe: boolean;
+}): boolean {
+  const isContract = !!walletBytecode && walletBytecode !== "0x";
+  return needsApproval && walletLookupSettled && !isContract && !isSafe;
+}
+
+/** Fall back only for wallets that cannot sign typed data, never on rejection. */
+export function permit2SignatureNeedsOnchainFallback(error: unknown): boolean {
+  const messages: string[] = [];
+  let current: unknown = error;
+  for (let depth = 0; current && depth < 5; depth += 1) {
+    if (typeof current !== "object") break;
+    const value = current as Record<string, unknown>;
+    for (const key of ["code", "shortMessage", "message", "details"]) {
+      if (value[key] !== undefined) messages.push(String(value[key]));
+    }
+    current = value.cause;
+  }
+  const text = messages.join(" ").toLowerCase();
+  if (/user rejected|rejected the request|denied|4001/.test(text)) return false;
+  return /(^|\s)-32602(\s|$)|(^|\s)-32601(\s|$)|(^|\s)4200(\s|$)|invalid parameters|method .*not supported|unsupported method|typed data.*not supported/.test(
+    text,
+  );
+}

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -7,11 +7,11 @@ const repositoryUrl = "https://github.com/Bananapus/juice-sdk-v4";
 const budgets = {
   "@bananapus/nana-sdk-core": {
     directory: "packages/core",
-    // Includes the public Bendystraw transport and explicit supported-chain
-    // definitions in both ESM and CJS formats.
-    packed: 775_000,
-    unpacked: 16_800_000,
-    entries: 365,
+    // Includes the public Bendystraw transport, supported-chain definitions,
+    // direct-pay routing, and Permit2 helpers in both ESM and CJS formats.
+    packed: 790_000,
+    unpacked: 16_950_000,
+    entries: 380,
   },
   "@bananapus/nana-sdk-react": {
     directory: "packages/react",

--- a/test/format-debt.json
+++ b/test/format-debt.json
@@ -12,8 +12,6 @@
     "packages/core/src/utils/hook.ts": "40e5c69767ccd19354e1c5fdd8fdb24d03655d1ee7e1ab2376aa5ef1fd887d98",
     "packages/core/src/utils/revnet.ts": "4ce8edaa7ee22a4954d9bce253038f2a096e72d4d592a132e23dc854d5dfa644",
     "packages/core/src/utils/ruleset.test.ts": "7339ccffd77c43ab55628e08330629ac0af3ec7d813b9c6b3d716d7d45c9ba24",
-    "packages/core/src/v6/loans.test.ts": "4df7587bd481407aa951c822c3ade6185e0f2600d9fe3c730ba38e7720b3a95b",
-    "packages/core/src/v6/loans.ts": "3d5f7ac17195804ae2589b4be5597ced493ed8e6b701498dbb87b0ca5af4ced3",
     "packages/react/src/components/NativeTokenValue.tsx": "e93d648614c7f307701e80f7276bfaf6077e7fd2bd08c3930356f1adb12cc0ba",
     "packages/react/src/contexts/JBChainContext/JBChainContext.tsx": "ec81d902ce5d01d3c287da3dfdf6d6ebc89b29fb93c9d36150bea2c178bc6e0a",
     "packages/react/src/contexts/JBContractContext/JBContractContext.tsx": "7e70a1d3d6b2cc2abd4ce66ee0913a4477b05286433158e61ddd12b03627fe09",


### PR DESCRIPTION
## Summary

- add reusable direct-pay quoting and transaction construction for native and USDC inputs across Ethereum, Optimism, Base, and Arbitrum
- add Permit2 typed-data, allowance, and fallback helpers for the shared payment sequence
- add contract-aligned loan opening and net-proceeds helpers
- export the new v6 APIs and cover them with focused unit and public-surface tests

## Verification

- `npm run check`
- 465 package tests pass with coverage
- generated-code and package-budget checks pass

## Release

- includes a minor changeset for `@bananapus/nana-sdk-core`