### PR TITLE
fix: expose tree-shakeable v6 helpers

### DIFF
--- a/.changeset/calm-trees-shake.md
+++ b/.changeset/calm-trees-shake.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-core": patch
+---
+
+Add narrow v6 payment, Permit2, loan math, cash-out, Uniswap V4, and Uniswap deployment entry points and mark the core package as side-effect free so browser bundlers can exclude unrelated SDK modules. Pure loan arithmetic no longer imports transaction-builder ABIs.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@bananapus/nana-sdk-core",
   "version": "1.10.0",
   "type": "module",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/Bananapus/juice-sdk-v4",
@@ -29,6 +30,41 @@
       "types": "./dist/esm/v6/index.d.ts",
       "import": "./dist/esm/v6/index.js",
       "require": "./dist/cjs/v6/index.js"
+    },
+    "./v6/direct-pay": {
+      "types": "./dist/esm/v6/directPay.d.ts",
+      "import": "./dist/esm/v6/directPay.js",
+      "require": "./dist/cjs/v6/directPay.js"
+    },
+    "./v6/permit2": {
+      "types": "./dist/esm/v6/permit2.d.ts",
+      "import": "./dist/esm/v6/permit2.js",
+      "require": "./dist/cjs/v6/permit2.js"
+    },
+    "./v6/loans": {
+      "types": "./dist/esm/v6/loans.d.ts",
+      "import": "./dist/esm/v6/loans.js",
+      "require": "./dist/cjs/v6/loans.js"
+    },
+    "./v6/loan-math": {
+      "types": "./dist/esm/v6/loanMath.d.ts",
+      "import": "./dist/esm/v6/loanMath.js",
+      "require": "./dist/cjs/v6/loanMath.js"
+    },
+    "./v6/cash-out": {
+      "types": "./dist/esm/v6/cashOut.d.ts",
+      "import": "./dist/esm/v6/cashOut.js",
+      "require": "./dist/cjs/v6/cashOut.js"
+    },
+    "./v6/uniswap-v4": {
+      "types": "./dist/esm/v6/uniswapV4.d.ts",
+      "import": "./dist/esm/v6/uniswapV4.js",
+      "require": "./dist/cjs/v6/uniswapV4.js"
+    },
+    "./v6/uniswap-v4-deployments": {
+      "types": "./dist/esm/v6/uniswapV4Deployments.d.ts",
+      "import": "./dist/esm/v6/uniswapV4Deployments.js",
+      "require": "./dist/cjs/v6/uniswapV4Deployments.js"
     }
   },
   "files": [

--- a/packages/core/src/v6/loanMath.ts
+++ b/packages/core/src/v6/loanMath.ts
@@ -1,0 +1,78 @@
+/**
+ * The denominator for REVLoans fee percents: prepaid fee percents and source fee percents
+ * are expressed out of 1000.
+ */
+export const LOANS_MAX_FEE = 1000n;
+
+/**
+ * The minimum `prepaidFeePercent` REVLoans accepts when borrowing: 25 of
+ * {@link LOANS_MAX_FEE} (2.5%), paid upfront to the source revnet.
+ */
+export const MIN_PREPAID_FEE_PERCENT = 25n;
+
+/** The largest prepaid source fee REVLoans accepts: 500 / 1000 = 50%. */
+export const MAX_PREPAID_FEE_PERCENT = 500n;
+
+/** The upfront fee REVLoans routes to the $REV revnet on every borrow: 1%. */
+export const REV_PREPAID_FEE_PERCENT = 10n;
+
+export interface LoanOpeningAmounts {
+  grossBorrowAmount: bigint;
+  protocolFee: bigint;
+  revFee: bigint;
+  sourceFee: bigint;
+  netBorrowAmount: bigint;
+}
+
+/**
+ * Calculate spendable loan proceeds using the contracts' floor-rounded fee arithmetic.
+ */
+export function loanOpeningAmounts({
+  grossBorrowAmount,
+  prepaidSourceFeePercent = MIN_PREPAID_FEE_PERCENT,
+  protocolFeeApplies = true,
+  revFeeApplies = true,
+}: {
+  grossBorrowAmount: bigint;
+  prepaidSourceFeePercent?: bigint;
+  protocolFeeApplies?: boolean;
+  revFeeApplies?: boolean;
+}): LoanOpeningAmounts {
+  if (grossBorrowAmount < 0n) {
+    throw new Error("grossBorrowAmount cannot be negative.");
+  }
+  if (
+    prepaidSourceFeePercent < MIN_PREPAID_FEE_PERCENT ||
+    prepaidSourceFeePercent > MAX_PREPAID_FEE_PERCENT
+  ) {
+    throw new Error(
+      `prepaidSourceFeePercent must be between ${MIN_PREPAID_FEE_PERCENT} and ${MAX_PREPAID_FEE_PERCENT}.`,
+    );
+  }
+  const protocolFee = protocolFeeApplies ? grossBorrowAmount / 40n : 0n;
+  const revFee = revFeeApplies
+    ? (grossBorrowAmount * REV_PREPAID_FEE_PERCENT) / LOANS_MAX_FEE
+    : 0n;
+  const sourceFee =
+    (grossBorrowAmount * prepaidSourceFeePercent) / LOANS_MAX_FEE;
+  const totalFees = protocolFee + revFee + sourceFee;
+  return {
+    grossBorrowAmount,
+    protocolFee,
+    revFee,
+    sourceFee,
+    netBorrowAmount:
+      grossBorrowAmount > totalFees ? grossBorrowAmount - totalFees : 0n,
+  };
+}
+
+/** Convenience accessor for {@link loanOpeningAmounts}. */
+export function netLoanProceeds(
+  grossBorrowAmount: bigint,
+  prepaidSourceFeePercent = MIN_PREPAID_FEE_PERCENT,
+): bigint {
+  return loanOpeningAmounts({
+    grossBorrowAmount,
+    prepaidSourceFeePercent,
+  }).netBorrowAmount;
+}

--- a/packages/core/src/v6/loans.ts
+++ b/packages/core/src/v6/loans.ts
@@ -1,96 +1,9 @@
 import { Address, Hex, PublicClient } from "viem";
 import { revLoansAbi } from "../generated/juicebox.js";
 import { JBChainId } from "../types.js";
+import { LOANS_MAX_FEE, MIN_PREPAID_FEE_PERCENT } from "./loanMath.js";
 import { v6Address } from "./types.js";
-
-/**
- * The denominator for REVLoans fee percents: prepaid fee percents and source fee percents
- * are expressed out of 1000.
- */
-export const LOANS_MAX_FEE = 1000n;
-
-/**
- * The minimum `prepaidFeePercent` REVLoans accepts when borrowing: 25 of {@link LOANS_MAX_FEE}
- * (2.5%), paid upfront to the source revnet. Prepaying more than the minimum extends the
- * loan's zero-additional-cost duration; after it expires the repayment cost increases
- * linearly until the loan liquidates at 10 years.
- */
-export const MIN_PREPAID_FEE_PERCENT = 25n;
-
-/** The largest prepaid source fee REVLoans accepts: 500 / 1000 = 50%. */
-export const MAX_PREPAID_FEE_PERCENT = 500n;
-
-/**
- * The upfront fee REVLoans routes to the $REV revnet on every borrow: 10 of
- * {@link LOANS_MAX_FEE} (1%), taken in addition to the prepaid fee.
- */
-export const REV_PREPAID_FEE_PERCENT = 10n;
-
-export interface LoanOpeningAmounts {
-  grossBorrowAmount: bigint;
-  protocolFee: bigint;
-  revFee: bigint;
-  sourceFee: bigint;
-  netBorrowAmount: bigint;
-}
-
-/**
- * Calculate a borrower's spendable proceeds using the same floor-rounded fee
- * arithmetic as REVLoans, JBMultiTerminal, and JBFees.
- *
- * `grossBorrowAmount` is the principal recorded on the loan. The terminal's
- * standard 2.5% allowance fee is deducted first, followed by REVLoans' 1% REV
- * fee and the selected prepaid source fee (2.5% minimum).
- */
-export function loanOpeningAmounts({
-  grossBorrowAmount,
-  prepaidSourceFeePercent = MIN_PREPAID_FEE_PERCENT,
-  protocolFeeApplies = true,
-  revFeeApplies = true,
-}: {
-  grossBorrowAmount: bigint;
-  prepaidSourceFeePercent?: bigint;
-  protocolFeeApplies?: boolean;
-  revFeeApplies?: boolean;
-}): LoanOpeningAmounts {
-  if (grossBorrowAmount < 0n) {
-    throw new Error("grossBorrowAmount cannot be negative.");
-  }
-  if (
-    prepaidSourceFeePercent < MIN_PREPAID_FEE_PERCENT ||
-    prepaidSourceFeePercent > MAX_PREPAID_FEE_PERCENT
-  ) {
-    throw new Error(
-      `prepaidSourceFeePercent must be between ${MIN_PREPAID_FEE_PERCENT} and ${MAX_PREPAID_FEE_PERCENT}.`,
-    );
-  }
-  const protocolFee = protocolFeeApplies ? grossBorrowAmount / 40n : 0n;
-  const revFee = revFeeApplies
-    ? (grossBorrowAmount * REV_PREPAID_FEE_PERCENT) / LOANS_MAX_FEE
-    : 0n;
-  const sourceFee =
-    (grossBorrowAmount * prepaidSourceFeePercent) / LOANS_MAX_FEE;
-  const totalFees = protocolFee + revFee + sourceFee;
-  return {
-    grossBorrowAmount,
-    protocolFee,
-    revFee,
-    sourceFee,
-    netBorrowAmount:
-      grossBorrowAmount > totalFees ? grossBorrowAmount - totalFees : 0n,
-  };
-}
-
-/** Convenience accessor for {@link loanOpeningAmounts}. */
-export function netLoanProceeds(
-  grossBorrowAmount: bigint,
-  prepaidSourceFeePercent = MIN_PREPAID_FEE_PERCENT,
-): bigint {
-  return loanOpeningAmounts({
-    grossBorrowAmount,
-    prepaidSourceFeePercent,
-  }).netBorrowAmount;
-}
+export * from "./loanMath.js";
 
 /**
  * The JBPermissions permission id apps grant to the REVLoans contract before borrowing

--- a/packages/core/src/v6/permit2.ts
+++ b/packages/core/src/v6/permit2.ts
@@ -1,7 +1,10 @@
 import type { Address, Hex, PublicClient } from "viem";
 import { NATIVE_TOKEN } from "../constants.js";
 import type { JBChainId } from "../types.js";
-import { UNISWAP_PERMIT2_ADDRESS, uniswapV4Deployment } from "./uniswapV4.js";
+import {
+  UNISWAP_PERMIT2_ADDRESS,
+  uniswapV4Deployment,
+} from "./uniswapV4Deployments.js";
 
 /** Canonical Permit2 deployment shared by supported EVM chains. */
 export const PERMIT2_ADDRESS = UNISWAP_PERMIT2_ADDRESS;

--- a/packages/core/src/v6/uniswapV4.ts
+++ b/packages/core/src/v6/uniswapV4.ts
@@ -9,104 +9,11 @@ import {
 import type { Address, Hex, PublicClient } from "viem";
 import { NATIVE_TOKEN } from "../constants.js";
 import type { JBChainId } from "../types.js";
-
-/**
- * Canonical Uniswap V4 PoolManager deployments used by Juicebox v6.
- * Optimism Sepolia is intentionally absent: deploy-all skips the Uniswap stack
- * there because Uniswap has not published supported V4 periphery deployments.
- */
-export const UNISWAP_V4_POOL_MANAGER_ADDRESSES: Readonly<
-  Partial<Record<JBChainId, Address>>
-> = {
-  1: "0x000000000004444c5dc75cb358380d2e3de08a90",
-  10: "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
-  8453: "0x498581ff718922c3f8e6a244956af099b2652b2b",
-  42161: "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
-  84532: "0x05e73354cfdd6745c338b50bcfdfa3aa6fa03408",
-  421614: "0xfb3e0c6f74eb1a21cc1da29aec80d2dfe6c9a317",
-  11155111: "0xe03a1074c86cfedd5c142c4f04f1a1536e203543",
-};
-
-/** Canonical Uniswap V4 PositionManager deployments used by Juicebox v6. */
-export const UNISWAP_V4_POSITION_MANAGER_ADDRESSES: Readonly<
-  Partial<Record<JBChainId, Address>>
-> = {
-  1: "0xbd216513d74c8cf14cf4747e6aaa6420ff64ee9e",
-  10: "0x3c3ea4b57a46241e54610e5f022e5c45859a1017",
-  8453: "0x7c5f5a4bbd8fd63184577525326123b519429bdc",
-  42161: "0xd88f38f930b7952f2db2432cb002e7abbf3dd869",
-  84532: "0x4b2c77d209d3405f41a037ec6c77f7f5b8e2ca80",
-  421614: "0xac631556d3d4019c95769033b5e719dd77124bac",
-  11155111: "0x429ba70129df741b2ca2a85bc3a2a3328e5c09b4",
-};
-
-/** Canonical V4Quoter deployments; missing chains must fail closed. */
-export const UNISWAP_V4_QUOTER_ADDRESSES: Readonly<
-  Partial<Record<JBChainId, Address>>
-> = {
-  1: "0x52f0e24d1c21c8a0cb1e5a5dd6198556bd9e1203",
-  10: "0x1f3131a13296fb91c90870043742c3cdbff1a8d7",
-  8453: "0x0d5e0f971ed27fbff6c2837bf31316121532048d",
-  42161: "0x3972c00f7ed4885e145823eb7c655375d275a1c5",
-  84532: "0x4a6513c898fe1b2d0e78d3b0e0a4a151589b1cba",
-  421614: "0x7de51022d70a725b508085468052e25e22b5c4c9",
-  11155111: "0x61b3f2011a92d183c7dbadbda940a7555ccf9227",
-};
-
-/** Canonical Universal Router deployments which support the V4_SWAP command. */
-export const UNISWAP_V4_UNIVERSAL_ROUTER_ADDRESSES: Readonly<
-  Partial<Record<JBChainId, Address>>
-> = {
-  1: "0x66a9893cc07d91d95644aedd05d03f95e1dba8af",
-  10: "0x851116d9223fabed8e56c0e6b8ad0c31d98b3507",
-  8453: "0x6ff5693b99212da76ad316178a184ab56d299b43",
-  42161: "0xa51afafe0263b40edaef0df8781ea9aa03e381a3",
-  84532: "0x492e6456d9528771018deb9e87ef7750ef184104",
-  421614: "0xefd1d4bd4cf1e86da286bb4cb1b8bced9c10ba47",
-  11155111: "0x3A9D48AB9751398BbFa63ad67599Bb04e4BdF98b",
-};
-
-/** Permit2 is deployed at the same address on supported EVM chains. */
-export const UNISWAP_PERMIT2_ADDRESS: Address =
-  "0x000000000022D473030F116dDEE9F6B43aC78BA3";
-
-/** Resolve the supported V4 surface for a chain without guessing addresses. */
-export function uniswapV4Deployment(chainId: number): {
-  poolManager: Address;
-  positionManager: Address | null;
-  quoter: Address | null;
-  universalRouter: Address | null;
-  permit2: Address;
-} | null {
-  const poolManager = (
-    UNISWAP_V4_POOL_MANAGER_ADDRESSES as Readonly<
-      Partial<Record<number, Address>>
-    >
-  )[chainId];
-  if (!poolManager) return null;
-  return {
-    poolManager,
-    positionManager:
-      (
-        UNISWAP_V4_POSITION_MANAGER_ADDRESSES as Readonly<
-          Partial<Record<number, Address>>
-        >
-      )[chainId] ?? null,
-    quoter:
-      (
-        UNISWAP_V4_QUOTER_ADDRESSES as Readonly<
-          Partial<Record<number, Address>>
-        >
-      )[chainId] ?? null,
-    universalRouter:
-      (
-        UNISWAP_V4_UNIVERSAL_ROUTER_ADDRESSES as Readonly<
-          Partial<Record<number, Address>>
-        >
-      )[chainId] ?? null,
-    permit2: UNISWAP_PERMIT2_ADDRESS,
-  };
-}
+import {
+  UNISWAP_V4_POOL_MANAGER_ADDRESSES,
+  uniswapV4Deployment,
+} from "./uniswapV4Deployments.js";
+export * from "./uniswapV4Deployments.js";
 
 export const UNISWAP_V4_Q96 = 1n << 96n;
 export const UNISWAP_V4_MAX_TICK = 887_272;

--- a/packages/core/src/v6/uniswapV4Deployments.ts
+++ b/packages/core/src/v6/uniswapV4Deployments.ts
@@ -1,0 +1,96 @@
+import type { Address } from "viem";
+import type { JBChainId } from "../types.js";
+
+/** Canonical PoolManager deployments used by Juicebox v6. */
+export const UNISWAP_V4_POOL_MANAGER_ADDRESSES: Readonly<
+  Partial<Record<JBChainId, Address>>
+> = {
+  1: "0x000000000004444c5dc75cb358380d2e3de08a90",
+  10: "0x9a13f98cb987694c9f086b1f5eb990eea8264ec3",
+  8453: "0x498581ff718922c3f8e6a244956af099b2652b2b",
+  42161: "0x360e68faccca8ca495c1b759fd9eee466db9fb32",
+  84532: "0x05e73354cfdd6745c338b50bcfdfa3aa6fa03408",
+  421614: "0xfb3e0c6f74eb1a21cc1da29aec80d2dfe6c9a317",
+  11155111: "0xe03a1074c86cfedd5c142c4f04f1a1536e203543",
+};
+
+/** Canonical PositionManager deployments used by Juicebox v6. */
+export const UNISWAP_V4_POSITION_MANAGER_ADDRESSES: Readonly<
+  Partial<Record<JBChainId, Address>>
+> = {
+  1: "0xbd216513d74c8cf14cf4747e6aaa6420ff64ee9e",
+  10: "0x3c3ea4b57a46241e54610e5f022e5c45859a1017",
+  8453: "0x7c5f5a4bbd8fd63184577525326123b519429bdc",
+  42161: "0xd88f38f930b7952f2db2432cb002e7abbf3dd869",
+  84532: "0x4b2c77d209d3405f41a037ec6c77f7f5b8e2ca80",
+  421614: "0xac631556d3d4019c95769033b5e719dd77124bac",
+  11155111: "0x429ba70129df741b2ca2a85bc3a2a3328e5c09b4",
+};
+
+/** Canonical V4Quoter deployments; missing chains must fail closed. */
+export const UNISWAP_V4_QUOTER_ADDRESSES: Readonly<
+  Partial<Record<JBChainId, Address>>
+> = {
+  1: "0x52f0e24d1c21c8a0cb1e5a5dd6198556bd9e1203",
+  10: "0x1f3131a13296fb91c90870043742c3cdbff1a8d7",
+  8453: "0x0d5e0f971ed27fbff6c2837bf31316121532048d",
+  42161: "0x3972c00f7ed4885e145823eb7c655375d275a1c5",
+  84532: "0x4a6513c898fe1b2d0e78d3b0e0a4a151589b1cba",
+  421614: "0x7de51022d70a725b508085468052e25e22b5c4c9",
+  11155111: "0x61b3f2011a92d183c7dbadbda940a7555ccf9227",
+};
+
+/** Canonical Universal Router deployments which support V4 swaps. */
+export const UNISWAP_V4_UNIVERSAL_ROUTER_ADDRESSES: Readonly<
+  Partial<Record<JBChainId, Address>>
+> = {
+  1: "0x66a9893cc07d91d95644aedd05d03f95e1dba8af",
+  10: "0x851116d9223fabed8e56c0e6b8ad0c31d98b3507",
+  8453: "0x6ff5693b99212da76ad316178a184ab56d299b43",
+  42161: "0xa51afafe0263b40edaef0df8781ea9aa03e381a3",
+  84532: "0x492e6456d9528771018deb9e87ef7750ef184104",
+  421614: "0xefd1d4bd4cf1e86da286bb4cb1b8bced9c10ba47",
+  11155111: "0x3A9D48AB9751398BbFa63ad67599Bb04e4BdF98b",
+};
+
+/** Permit2 is deployed at the same address on supported EVM chains. */
+export const UNISWAP_PERMIT2_ADDRESS: Address =
+  "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+
+/** Resolve the supported V4 surface for a chain without guessing addresses. */
+export function uniswapV4Deployment(chainId: number): {
+  poolManager: Address;
+  positionManager: Address | null;
+  quoter: Address | null;
+  universalRouter: Address | null;
+  permit2: Address;
+} | null {
+  const poolManager = (
+    UNISWAP_V4_POOL_MANAGER_ADDRESSES as Readonly<
+      Partial<Record<number, Address>>
+    >
+  )[chainId];
+  if (!poolManager) return null;
+  return {
+    poolManager,
+    positionManager:
+      (
+        UNISWAP_V4_POSITION_MANAGER_ADDRESSES as Readonly<
+          Partial<Record<number, Address>>
+        >
+      )[chainId] ?? null,
+    quoter:
+      (
+        UNISWAP_V4_QUOTER_ADDRESSES as Readonly<
+          Partial<Record<number, Address>>
+        >
+      )[chainId] ?? null,
+    universalRouter:
+      (
+        UNISWAP_V4_UNIVERSAL_ROUTER_ADDRESSES as Readonly<
+          Partial<Record<number, Address>>
+        >
+      )[chainId] ?? null,
+    permit2: UNISWAP_PERMIT2_ADDRESS,
+  };
+}

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -8,10 +8,11 @@ const budgets = {
   "@bananapus/nana-sdk-core": {
     directory: "packages/core",
     // Includes the public Bendystraw transport, supported-chain definitions,
-    // direct-pay routing, and Permit2 helpers in both ESM and CJS formats.
+    // direct-pay routing, Permit2 helpers, and tree-shakable loan/deployment
+    // entry points in both ESM and CJS formats.
     packed: 790_000,
     unpacked: 16_950_000,
-    entries: 380,
+    entries: 395,
   },
   "@bananapus/nana-sdk-react": {
     directory: "packages/react",


### PR DESCRIPTION
## Summary
- mark the core SDK package as side-effect free
- expose narrow `v6/direct-pay`, `v6/permit2`, and `v6/loans` entry points
- preserve the existing `v6` barrel API

## Validation
- `npm run check` (465 tests, type checks, builds, generated checks, package budgets)