### PR TITLE
Add Uniswap V4 LP fee reads and a fee-collect builder

### DIFF
--- a/.changeset/lp-fee-reads-and-collect.md
+++ b/.changeset/lp-fee-reads-and-collect.md
@@ -1,0 +1,11 @@
+---
+"@bananapus/nana-sdk-core": minor
+---
+
+Add Uniswap V4 LP fee reads and a fee-collect transaction builder.
+
+`readUniswapV4PositionFees` reports a position's unclaimed fees through the
+canonical StateView lens (now in `UNISWAP_V4_STATE_VIEW_ADDRESSES` and
+`uniswapV4Deployment`), and `buildCollectUniswapV4FeesTx` encodes the
+zero-liquidity decrease that sweeps them without touching the position.
+`uniswapV4FeesOwed` and `uniswapV4PositionId` expose the underlying math.

--- a/packages/core/src/v6/index.ts
+++ b/packages/core/src/v6/index.ts
@@ -15,6 +15,7 @@ export * from "./cashOut.js";
 export * from "./nft.js";
 export * from "./tokens.js";
 export * from "./uniswapV4.js";
+export * from "./uniswapV4Fees.js";
 export * from "./permissions.js";
 export * from "./suckers.js";
 export * from "./loans.js";

--- a/packages/core/src/v6/uniswapV4Deployments.ts
+++ b/packages/core/src/v6/uniswapV4Deployments.ts
@@ -53,6 +53,23 @@ export const UNISWAP_V4_UNIVERSAL_ROUTER_ADDRESSES: Readonly<
   11155111: "0x3A9D48AB9751398BbFa63ad67599Bb04e4BdF98b",
 };
 
+/**
+ * Canonical StateView deployments — the periphery lens over PoolManager's
+ * `extsload` storage. Each address was verified by calling `poolManager()` and
+ * matching it against {@link UNISWAP_V4_POOL_MANAGER_ADDRESSES} for the chain.
+ */
+export const UNISWAP_V4_STATE_VIEW_ADDRESSES: Readonly<
+  Partial<Record<JBChainId, Address>>
+> = {
+  1: "0x7ffe42c4a5deea5b0fec41c94c136cf115597227",
+  10: "0xc18a3169788f4f75a170290584eca6395c75ecdb",
+  8453: "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
+  42161: "0x76fd297e2d437cd7f76d50f01afe6160f86e9990",
+  84532: "0x571291b572ed32ce6751a2cb2486ebee8defb9b4",
+  421614: "0x9d467fa9062b6e9b1a46e26007ad82db116c67cb",
+  11155111: "0xe1dd9c3fa50edb962e442f60dfbc432e24537e4c",
+};
+
 /** Permit2 is deployed at the same address on supported EVM chains. */
 export const UNISWAP_PERMIT2_ADDRESS: Address =
   "0x000000000022D473030F116dDEE9F6B43aC78BA3";
@@ -63,6 +80,7 @@ export function uniswapV4Deployment(chainId: number): {
   positionManager: Address | null;
   quoter: Address | null;
   universalRouter: Address | null;
+  stateView: Address | null;
   permit2: Address;
 } | null {
   const poolManager = (
@@ -88,6 +106,12 @@ export function uniswapV4Deployment(chainId: number): {
     universalRouter:
       (
         UNISWAP_V4_UNIVERSAL_ROUTER_ADDRESSES as Readonly<
+          Partial<Record<number, Address>>
+        >
+      )[chainId] ?? null,
+    stateView:
+      (
+        UNISWAP_V4_STATE_VIEW_ADDRESSES as Readonly<
           Partial<Record<number, Address>>
         >
       )[chainId] ?? null,

--- a/packages/core/src/v6/uniswapV4Fees.test.ts
+++ b/packages/core/src/v6/uniswapV4Fees.test.ts
@@ -1,0 +1,211 @@
+import { decodeAbiParameters, decodeFunctionData } from "viem";
+import { describe, expect, test } from "vitest";
+import {
+  buildCollectUniswapV4FeesTx,
+  readUniswapV4PositionFees,
+  uniswapV4FeesOwed,
+  uniswapV4PositionId,
+} from "./uniswapV4Fees.js";
+import { UNISWAP_V4_STATE_VIEW_ADDRESSES } from "./uniswapV4Deployments.js";
+
+// The ART/USDC pool on Base, read at block 49458950. Keeping a real position
+// here pins the whole chain of math against state that actually existed.
+const ART_USDC_POOL =
+  "0x760dee01ca4afcf02e6aaa16a59d809c08e16895652b01c4306f5536760bb77d" as const;
+const BASE_POSITION_MANAGER =
+  "0x7c5f5a4bbd8fd63184577525326123b519429bdc" as const;
+const ART = "0x44c4516768e47cd97cff2561b81a74699f23f8ec" as const;
+const USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" as const;
+const TOKEN_ID = 2864727n;
+const TICK_LOWER = -392200;
+const TICK_UPPER = -340600;
+const LIQUIDITY = 143800072655163317n;
+const FEE_GROWTH_INSIDE_1 = 32541020662148266151501820090n;
+
+describe("uniswapV4PositionId", () => {
+  test("matches the pool's key for a live PositionManager position", () => {
+    // Verified against StateView.getPositionInfo on Base: this id returns the
+    // position's real liquidity, so the packing (address, int24, int24, bytes32)
+    // is right — a wrong key silently reads an empty position instead.
+    expect(
+      uniswapV4PositionId({
+        owner: BASE_POSITION_MANAGER,
+        tickLower: TICK_LOWER,
+        tickUpper: TICK_UPPER,
+        salt: TOKEN_ID,
+      }),
+    ).toBe(
+      "0x34bf69524209147fed65f9af6b1b20091647aff24618aeb98279c5b48767e734",
+    );
+  });
+});
+
+describe("uniswapV4FeesOwed", () => {
+  test("computes the live position's unclaimed fees", () => {
+    expect(
+      uniswapV4FeesOwed({
+        liquidity: LIQUIDITY,
+        feeGrowthInsideLastX128: 0n,
+        feeGrowthInsideX128: FEE_GROWTH_INSIDE_1,
+      }),
+    ).toBe(13751523n); // 13.751523 USDC
+  });
+
+  test("treats a wrapped accumulator as forward progress", () => {
+    // Pool fee growth is unchecked uint256 and is expected to wrap. A checked
+    // subtraction would read this as a colossal negative and either throw or
+    // report a nonsense balance.
+    const max = (1n << 256n) - 1n;
+    expect(
+      uniswapV4FeesOwed({
+        liquidity: 1n << 128n,
+        feeGrowthInsideLastX128: max - 3n,
+        feeGrowthInsideX128: 4n,
+      }),
+    ).toBe(8n);
+  });
+
+  test("reports nothing for a closed position", () => {
+    expect(
+      uniswapV4FeesOwed({
+        liquidity: 0n,
+        feeGrowthInsideLastX128: 0n,
+        feeGrowthInsideX128: FEE_GROWTH_INSIDE_1,
+      }),
+    ).toBe(0n);
+  });
+
+  test("reports nothing when no growth has accrued since the checkpoint", () => {
+    expect(
+      uniswapV4FeesOwed({
+        liquidity: LIQUIDITY,
+        feeGrowthInsideLastX128: FEE_GROWTH_INSIDE_1,
+        feeGrowthInsideX128: FEE_GROWTH_INSIDE_1,
+      }),
+    ).toBe(0n);
+  });
+});
+
+describe("readUniswapV4PositionFees", () => {
+  test("resolves the chain's StateView and pairs both currencies", async () => {
+    const calls: { address: string; functionName: string }[] = [];
+    const client = {
+      readContract: async ({
+        address,
+        functionName,
+      }: {
+        address: string;
+        functionName: string;
+      }) => {
+        calls.push({ address, functionName });
+        if (functionName === "getPositionInfo") {
+          return [LIQUIDITY, 0n, 0n];
+        }
+        return [0n, FEE_GROWTH_INSIDE_1];
+      },
+    } as never;
+
+    const fees = await readUniswapV4PositionFees(client, {
+      chainId: 8453,
+      poolId: ART_USDC_POOL,
+      positionManager: BASE_POSITION_MANAGER,
+      tokenId: TOKEN_ID,
+      tickLower: TICK_LOWER,
+      tickUpper: TICK_UPPER,
+    });
+
+    expect(fees).toEqual({
+      liquidity: LIQUIDITY,
+      amount0: 0n,
+      amount1: 13751523n,
+    });
+    expect(
+      calls.every(
+        (call) => call.address === UNISWAP_V4_STATE_VIEW_ADDRESSES[8453],
+      ),
+    ).toBe(true);
+  });
+
+  test("fails closed on a chain with no StateView deployment", async () => {
+    const client = { readContract: async () => [] } as never;
+    await expect(
+      readUniswapV4PositionFees(client, {
+        chainId: 11155420 as never,
+        poolId: ART_USDC_POOL,
+        positionManager: BASE_POSITION_MANAGER,
+        tokenId: TOKEN_ID,
+        tickLower: TICK_LOWER,
+        tickUpper: TICK_UPPER,
+      }),
+    ).rejects.toThrow(/StateView/);
+  });
+});
+
+describe("buildCollectUniswapV4FeesTx", () => {
+  test("encodes a zero-liquidity decrease paired with a take", () => {
+    const tx = buildCollectUniswapV4FeesTx({
+      positionManager: BASE_POSITION_MANAGER,
+      tokenId: TOKEN_ID,
+      currency0: ART,
+      currency1: USDC,
+      recipient: "0x63d2dfea64b3433f4071a98665bcd7ca14d93496",
+      deadline: 1_800_000_000n,
+    });
+
+    expect(tx.to).toBe(BASE_POSITION_MANAGER);
+    expect(tx.value).toBe(0n);
+
+    const call = decodeFunctionData({
+      abi: [
+        {
+          type: "function",
+          name: "modifyLiquidities",
+          stateMutability: "payable",
+          inputs: [
+            { name: "unlockData", type: "bytes" },
+            { name: "deadline", type: "uint256" },
+          ],
+          outputs: [],
+        },
+      ] as const,
+      data: tx.data,
+    });
+    expect(call.args[1]).toBe(1_800_000_000n);
+
+    const [actions, params] = decodeAbiParameters(
+      [{ type: "bytes" }, { type: "bytes[]" }],
+      call.args[0],
+    );
+    // DECREASE_LIQUIDITY (0x01) then TAKE_PAIR (0x11). Any other opcode pair
+    // would move liquidity instead of only sweeping fees.
+    expect(actions).toBe("0x0111");
+    expect(params).toHaveLength(2);
+
+    const [decodedTokenId, liquidity, amount0Min, amount1Min] =
+      decodeAbiParameters(
+        [
+          { type: "uint256" },
+          { type: "uint128" },
+          { type: "uint128" },
+          { type: "uint128" },
+          { type: "bytes" },
+        ],
+        params[0],
+      );
+    expect(decodedTokenId).toBe(TOKEN_ID);
+    expect(liquidity).toBe(0n);
+    expect(amount0Min).toBe(0n);
+    expect(amount1Min).toBe(0n);
+
+    expect(
+      decodeAbiParameters(
+        [{ type: "address" }, { type: "address" }, { type: "address" }],
+        params[1],
+      ),
+    ).toEqual([
+      "0x44c4516768e47cd97cfF2561B81a74699F23f8Ec",
+      "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "0x63D2DfEA64b3433F4071A98665bcD7Ca14d93496",
+    ]);
+  });
+});

--- a/packages/core/src/v6/uniswapV4Fees.ts
+++ b/packages/core/src/v6/uniswapV4Fees.ts
@@ -1,0 +1,272 @@
+import {
+  encodeAbiParameters,
+  encodeFunctionData,
+  encodePacked,
+  keccak256,
+  type Address,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import { UNISWAP_V4_STATE_VIEW_ADDRESSES } from "./uniswapV4Deployments.js";
+import type { JBChainId } from "../types.js";
+
+const UINT256_MAX = (1n << 256n) - 1n;
+const Q128 = 1n << 128n;
+
+const STATE_VIEW_ABI = [
+  {
+    type: "function",
+    name: "getFeeGrowthInside",
+    stateMutability: "view",
+    inputs: [
+      { name: "poolId", type: "bytes32" },
+      { name: "tickLower", type: "int24" },
+      { name: "tickUpper", type: "int24" },
+    ],
+    outputs: [
+      { name: "feeGrowthInside0X128", type: "uint256" },
+      { name: "feeGrowthInside1X128", type: "uint256" },
+    ],
+  },
+  {
+    type: "function",
+    name: "getPositionInfo",
+    stateMutability: "view",
+    inputs: [
+      { name: "poolId", type: "bytes32" },
+      { name: "positionId", type: "bytes32" },
+    ],
+    outputs: [
+      { name: "liquidity", type: "uint128" },
+      { name: "feeGrowthInside0LastX128", type: "uint256" },
+      { name: "feeGrowthInside1LastX128", type: "uint256" },
+    ],
+  },
+] as const;
+
+const POSITION_MANAGER_ABI = [
+  {
+    type: "function",
+    name: "modifyLiquidities",
+    stateMutability: "payable",
+    inputs: [
+      { name: "unlockData", type: "bytes" },
+      { name: "deadline", type: "uint256" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+/** v4-periphery `Actions.DECREASE_LIQUIDITY`. */
+const ACTION_DECREASE_LIQUIDITY = 0x01;
+/** v4-periphery `Actions.TAKE_PAIR`. */
+const ACTION_TAKE_PAIR = 0x11;
+
+/**
+ * The PoolManager position key: `keccak256(abi.encodePacked(owner, tickLower,
+ * tickUpper, salt))`. For a PositionManager-held position the owner is the
+ * PositionManager and the salt is the position's token id.
+ */
+export function uniswapV4PositionId({
+  owner,
+  tickLower,
+  tickUpper,
+  salt,
+}: {
+  owner: Address;
+  tickLower: number;
+  tickUpper: number;
+  salt: bigint;
+}): Hex {
+  return keccak256(
+    encodePacked(
+      ["address", "int24", "int24", "bytes32"],
+      [
+        owner,
+        tickLower,
+        tickUpper,
+        `0x${salt.toString(16).padStart(64, "0")}` as Hex,
+      ],
+    ),
+  );
+}
+
+/**
+ * Fees a position has accrued since its last checkpoint, from the pool's fee
+ * growth accumulators.
+ *
+ * @remarks Fee growth accumulators are unchecked `uint256` in the pool and are
+ * expected to wrap; the difference is therefore taken modulo 2^256, exactly as
+ * Solidity computes it. A checked subtraction would read a wrapped accumulator
+ * as a negative (or enormous) balance.
+ */
+export function uniswapV4FeesOwed({
+  liquidity,
+  feeGrowthInsideLastX128,
+  feeGrowthInsideX128,
+}: {
+  liquidity: bigint;
+  feeGrowthInsideLastX128: bigint;
+  feeGrowthInsideX128: bigint;
+}): bigint {
+  if (liquidity <= 0n) return 0n;
+  const delta = (feeGrowthInsideX128 - feeGrowthInsideLastX128) & UINT256_MAX;
+  return (delta * liquidity) / Q128;
+}
+
+export interface UniswapV4PositionFees {
+  /** Unclaimed currency0 fees, in currency0's own decimals. */
+  amount0: bigint;
+  /** Unclaimed currency1 fees, in currency1's own decimals. */
+  amount1: bigint;
+  /** The position's live liquidity, as the pool records it. */
+  liquidity: bigint;
+}
+
+/**
+ * Read a position's unclaimed fees through StateView.
+ *
+ * This is the fees CLAIMABLE NOW, not the position's lifetime earnings: the
+ * pool rewrites `feeGrowthInsideLast` on every collect, so anything already
+ * taken is no longer visible here. Reconstructing lifetime earnings means
+ * replaying the position's `ModifyLiquidity` events against archive state.
+ */
+export async function readUniswapV4PositionFees(
+  client: Pick<PublicClient, "readContract">,
+  {
+    chainId,
+    stateView,
+    poolId,
+    positionManager,
+    tokenId,
+    tickLower,
+    tickUpper,
+  }: {
+    chainId?: JBChainId;
+    /** Overrides the chain's canonical StateView deployment. */
+    stateView?: Address;
+    poolId: Hex;
+    positionManager: Address;
+    tokenId: bigint;
+    tickLower: number;
+    tickUpper: number;
+  },
+): Promise<UniswapV4PositionFees> {
+  const lens =
+    stateView ??
+    (chainId
+      ? (
+          UNISWAP_V4_STATE_VIEW_ADDRESSES as Readonly<
+            Partial<Record<number, Address>>
+          >
+        )[chainId]
+      : undefined);
+  if (!lens) {
+    throw new Error(
+      `No Uniswap V4 StateView deployment for chain ${chainId ?? "unknown"}.`,
+    );
+  }
+
+  const positionId = uniswapV4PositionId({
+    owner: positionManager,
+    tickLower,
+    tickUpper,
+    salt: tokenId,
+  });
+
+  const [position, inside] = await Promise.all([
+    client.readContract({
+      address: lens,
+      abi: STATE_VIEW_ABI,
+      functionName: "getPositionInfo",
+      args: [poolId, positionId],
+    }),
+    client.readContract({
+      address: lens,
+      abi: STATE_VIEW_ABI,
+      functionName: "getFeeGrowthInside",
+      args: [poolId, tickLower, tickUpper],
+    }),
+  ]);
+
+  const [liquidity, feeGrowthInside0Last, feeGrowthInside1Last] = position;
+  const [feeGrowthInside0, feeGrowthInside1] = inside;
+
+  return {
+    liquidity,
+    amount0: uniswapV4FeesOwed({
+      liquidity,
+      feeGrowthInsideLastX128: feeGrowthInside0Last,
+      feeGrowthInsideX128: feeGrowthInside0,
+    }),
+    amount1: uniswapV4FeesOwed({
+      liquidity,
+      feeGrowthInsideLastX128: feeGrowthInside1Last,
+      feeGrowthInsideX128: feeGrowthInside1,
+    }),
+  };
+}
+
+export interface UniswapV4CollectFeesTxRequest {
+  to: Address;
+  data: Hex;
+  value: bigint;
+}
+
+/**
+ * Collect a position's fees without touching its liquidity.
+ *
+ * A V4 "collect" is a zero-liquidity decrease: the pool settles the accrued
+ * fees into the position's delta, and TAKE_PAIR pays both currencies out. The
+ * minimum-out parameters are 0 because nothing is swapped — the amounts are
+ * whatever the pool has already accrued, so a floor could only make a valid
+ * claim revert.
+ */
+export function buildCollectUniswapV4FeesTx({
+  positionManager,
+  tokenId,
+  currency0,
+  currency1,
+  recipient,
+  deadline,
+}: {
+  positionManager: Address;
+  tokenId: bigint;
+  currency0: Address;
+  currency1: Address;
+  recipient: Address;
+  deadline: bigint;
+}): UniswapV4CollectFeesTxRequest {
+  const decreaseParams = encodeAbiParameters(
+    [
+      { type: "uint256" },
+      { type: "uint128" },
+      { type: "uint128" },
+      { type: "uint128" },
+      { type: "bytes" },
+    ],
+    [tokenId, 0n, 0n, 0n, "0x"],
+  );
+  const takeParams = encodeAbiParameters(
+    [{ type: "address" }, { type: "address" }, { type: "address" }],
+    [currency0, currency1, recipient],
+  );
+  const actions = encodePacked(
+    ["uint8", "uint8"],
+    [ACTION_DECREASE_LIQUIDITY, ACTION_TAKE_PAIR],
+  );
+  const unlockData = encodeAbiParameters(
+    [{ type: "bytes" }, { type: "bytes[]" }],
+    [actions, [decreaseParams, takeParams]],
+  );
+
+  return {
+    to: positionManager,
+    data: encodeFunctionData({
+      abi: POSITION_MANAGER_ABI,
+      functionName: "modifyLiquidities",
+      args: [unlockData, deadline],
+    }),
+    value: 0n,
+  };
+}

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -12,7 +12,7 @@ const budgets = {
     // entry points in both ESM and CJS formats.
     packed: 790_000,
     unpacked: 16_950_000,
-    entries: 395,
+    entries: 403,
   },
   "@bananapus/nana-sdk-react": {
     directory: "packages/react",


### PR DESCRIPTION
Four clients (juicebox.money, revnet.money, juicescan, juicy.vision) are about to show what an LP position has earned and let its owner take it. Without this they each derive the same fee-growth math locally.

**`readUniswapV4PositionFees`** reads a position's unclaimed fees through StateView, the periphery lens over PoolManager's `extsload` storage. Every address in the new `UNISWAP_V4_STATE_VIEW_ADDRESSES` was verified by calling `poolManager()` on it and matching the result against this repo's own `UNISWAP_V4_POOL_MANAGER_ADDRESSES` — all 7 chains checked, and an unknown chain fails closed instead of guessing.

**`buildCollectUniswapV4FeesTx`** encodes the zero-liquidity decrease that sweeps fees without touching the position (`DECREASE_LIQUIDITY` + `TAKE_PAIR`). The minimum-out params are 0 deliberately: nothing is swapped, so the amounts are whatever the pool already accrued and a floor could only make a valid claim revert.

**`uniswapV4FeesOwed`** takes the fee-growth difference modulo 2^256. The accumulators are unchecked `uint256` in the pool and are expected to wrap; a checked subtraction would read a wrapped accumulator as a colossal balance.

Also exposes `uniswapV4PositionId` (the `keccak256(abi.encodePacked(owner, tickLower, tickUpper, salt))` key) and adds `stateView` to `uniswapV4Deployment`.

### Verification

Pinned against a live Base position — the ART/USDC pool's only LP, token id 2864727:

- the derived position key returns that position's real liquidity from `StateView.getPositionInfo`
- the fee math reports **13.751523 USDC** owed, matching `liquidity × feeGrowthInside1 >> 128` on chain
- the collect calldata simulates clean from the position's owner, and reverts from a non-owner

### Note on lifetime earnings

This reads fees **claimable now**, not lifetime earnings — the pool rewrites `feeGrowthInsideLast` on every collect, so anything already taken is no longer visible. That limitation is documented on the function. Reconstructing lifetime totals means replaying a position's `ModifyLiquidity` events against archive state, which is out of scope here.

### Budget

`check-package-budgets` entries 395 → 403: the new module ships 8 files (ESM + CJS × js/d.ts/maps), keeping the same +1 headroom the previous number had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)