### PR TITLE
Add 721 ruleset transfer-pause metadata helpers

### DIFF
--- a/.changeset/quiet-721-ruleset-metadata.md
+++ b/.changeset/quiet-721-ruleset-metadata.md
@@ -1,0 +1,5 @@
+---
+"@bananapus/nana-sdk-core": patch
+---
+
+Add V6 721 ruleset metadata helpers which encode and decode transfer and reserve-mint pauses while preserving unrelated hook metadata bits.

--- a/packages/core/src/publicSurface.test.ts
+++ b/packages/core/src/publicSurface.test.ts
@@ -20,5 +20,7 @@ describe("published core SDK surfaces", () => {
     expect(v6.buildDirectPaySwapTx).toBeTypeOf("function");
     expect(v6.permit2TypedData).toBeTypeOf("function");
     expect(v6.netLoanProceeds).toBeTypeOf("function");
+    expect(v6.build721RulesetMetadata).toBeTypeOf("function");
+    expect(v6.decode721RulesetMetadata).toBeTypeOf("function");
   });
 });

--- a/packages/core/src/v6/nft.test.ts
+++ b/packages/core/src/v6/nft.test.ts
@@ -4,9 +4,14 @@ import { JBOmnichainDeployerContracts } from "../contracts.js";
 import { jbContractAddress } from "../generated/juicebox.js";
 import {
   DISCOUNT_DENOMINATOR,
+  JB721_RULESET_METADATA_PAUSE_MINT_PENDING_RESERVES,
+  JB721_RULESET_METADATA_PAUSE_TRANSFERS,
+  JB_RULESET_METADATA_APP_BITS_MAX,
   TIER_UNLIMITED_SUPPLY,
+  build721RulesetMetadata,
   buildTierCategoryPlan,
   buildTierMetadata,
+  decode721RulesetMetadata,
   effectiveTierPrice,
   get721MetadataIdTarget,
   getProject721Shop,
@@ -22,6 +27,79 @@ const hook = "0x1111111111111111111111111111111111111111" as const;
 const impl = "0x2222222222222222222222222222222222222222" as const;
 const store = "0x3333333333333333333333333333333333333333" as const;
 const CID = "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
+
+describe("721 ruleset metadata", () => {
+  test("sets and decodes both 721 hook flags", () => {
+    const metadata = build721RulesetMetadata({
+      pauseTransfers: true,
+      pauseMintPendingReserves: true,
+    });
+
+    expect(metadata).toBe(
+      JB721_RULESET_METADATA_PAUSE_TRANSFERS |
+        JB721_RULESET_METADATA_PAUSE_MINT_PENDING_RESERVES,
+    );
+    expect(decode721RulesetMetadata(metadata)).toEqual({
+      pauseTransfers: true,
+      pauseMintPendingReserves: true,
+    });
+  });
+
+  test("preserves unrelated metadata bits when setting or clearing flags", () => {
+    const unrelatedBits = (1 << 2) | (1 << 13);
+    expect(
+      build721RulesetMetadata({
+        metadata:
+          unrelatedBits | JB721_RULESET_METADATA_PAUSE_MINT_PENDING_RESERVES,
+        pauseTransfers: true,
+      }),
+    ).toBe(
+      unrelatedBits |
+        JB721_RULESET_METADATA_PAUSE_TRANSFERS |
+        JB721_RULESET_METADATA_PAUSE_MINT_PENDING_RESERVES,
+    );
+    expect(
+      build721RulesetMetadata({
+        metadata: unrelatedBits | JB721_RULESET_METADATA_PAUSE_TRANSFERS,
+        pauseTransfers: false,
+      }),
+    ).toBe(unrelatedBits);
+  });
+
+  test("preserves omitted flags and updates reserve minting independently", () => {
+    expect(
+      build721RulesetMetadata({
+        metadata: JB721_RULESET_METADATA_PAUSE_TRANSFERS,
+        pauseMintPendingReserves: true,
+      }),
+    ).toBe(
+      JB721_RULESET_METADATA_PAUSE_TRANSFERS |
+        JB721_RULESET_METADATA_PAUSE_MINT_PENDING_RESERVES,
+    );
+    expect(
+      build721RulesetMetadata({
+        metadata:
+          JB721_RULESET_METADATA_PAUSE_TRANSFERS |
+          JB721_RULESET_METADATA_PAUSE_MINT_PENDING_RESERVES,
+        pauseMintPendingReserves: false,
+      }),
+    ).toBe(JB721_RULESET_METADATA_PAUSE_TRANSFERS);
+  });
+
+  test.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 0x4000])(
+    "rejects invalid app metadata %s",
+    (metadata) => {
+      expect(() => build721RulesetMetadata({ metadata })).toThrow(/integer/);
+      expect(() => decode721RulesetMetadata(metadata)).toThrow(/integer/);
+    },
+  );
+
+  test("accepts the highest 14-bit metadata value", () => {
+    expect(
+      build721RulesetMetadata({ metadata: JB_RULESET_METADATA_APP_BITS_MAX }),
+    ).toBe(JB_RULESET_METADATA_APP_BITS_MAX);
+  });
+});
 
 describe("tier metadata", () => {
   test("parses encoded and base64 JSON data URIs", () => {

--- a/packages/core/src/v6/nft.ts
+++ b/packages/core/src/v6/nft.ts
@@ -23,6 +23,90 @@ export const TIER_UNLIMITED_SUPPLY = 999_999_999;
  */
 export const DISCOUNT_DENOMINATOR = 200n;
 
+/** The 721 tiers hook's ruleset-metadata bit which pauses eligible transfers. */
+export const JB721_RULESET_METADATA_PAUSE_TRANSFERS = 1 << 0;
+
+/** The 721 tiers hook's ruleset-metadata bit which pauses pending reserve mints. */
+export const JB721_RULESET_METADATA_PAUSE_MINT_PENDING_RESERVES = 1 << 1;
+
+/** The protocol stores 14 app-specific bits in `JBRulesetMetadata.metadata`. */
+export const JB_RULESET_METADATA_APP_BITS_MAX = 0x3fff;
+
+/** 721-specific overrides accepted by {@link build721RulesetMetadata}. */
+export interface JB721RulesetMetadataInput {
+  /** Existing app-specific metadata. Unrelated bits are preserved. */
+  metadata?: number;
+  /** Pause transfers for tiers whose `transfersPausable` flag is enabled. */
+  pauseTransfers?: boolean;
+  /** Pause minting the hook's pending reserve tokens. */
+  pauseMintPendingReserves?: boolean;
+}
+
+/** 721-specific flags decoded from app-specific ruleset metadata. */
+export interface JB721RulesetMetadata {
+  pauseTransfers: boolean;
+  pauseMintPendingReserves: boolean;
+}
+
+function assertRulesetAppMetadata(metadata: number): void {
+  if (
+    !Number.isInteger(metadata) ||
+    metadata < 0 ||
+    metadata > JB_RULESET_METADATA_APP_BITS_MAX
+  ) {
+    throw new Error(
+      `Ruleset app metadata must be an integer between 0 and ${JB_RULESET_METADATA_APP_BITS_MAX}.`,
+    );
+  }
+}
+
+function setMetadataFlag(
+  metadata: number,
+  flag: number,
+  enabled: boolean | undefined,
+): number {
+  if (enabled === undefined) return metadata;
+  return enabled ? metadata | flag : metadata & ~flag;
+}
+
+/**
+ * Set the 721 tiers hook's ruleset flags while preserving every unrelated app
+ * metadata bit. This is important when composing with other hooks; for
+ * example, Revnets use another bit to permit sucker deployment.
+ *
+ * A transfer is only paused when `pauseTransfers` is true AND the transferred
+ * tier was created with `transfersPausable`. Mints and burns remain possible.
+ * Omitted overrides preserve the corresponding bit in `metadata`.
+ */
+export function build721RulesetMetadata(
+  input: JB721RulesetMetadataInput = {},
+): number {
+  const metadata = input.metadata ?? 0;
+  assertRulesetAppMetadata(metadata);
+
+  return setMetadataFlag(
+    setMetadataFlag(
+      metadata,
+      JB721_RULESET_METADATA_PAUSE_TRANSFERS,
+      input.pauseTransfers,
+    ),
+    JB721_RULESET_METADATA_PAUSE_MINT_PENDING_RESERVES,
+    input.pauseMintPendingReserves,
+  );
+}
+
+/** Decode the 721 tiers hook's flags without interpreting unrelated bits. */
+export function decode721RulesetMetadata(
+  metadata: number,
+): JB721RulesetMetadata {
+  assertRulesetAppMetadata(metadata);
+  return {
+    pauseTransfers: (metadata & JB721_RULESET_METADATA_PAUSE_TRANSFERS) !== 0,
+    pauseMintPendingReserves:
+      (metadata & JB721_RULESET_METADATA_PAUSE_MINT_PENDING_RESERVES) !== 0,
+  };
+}
+
 /** Canonical display fields understood across Juicebox 721 metadata writers. */
 export interface TierMetadata {
   name?: string;

--- a/scripts/check-package-budgets.mjs
+++ b/scripts/check-package-budgets.mjs
@@ -10,7 +10,7 @@ const budgets = {
     // Includes the public Bendystraw transport, supported-chain definitions,
     // direct-pay routing, Permit2 helpers, and tree-shakable loan/deployment
     // entry points in both ESM and CJS formats.
-    packed: 790_000,
+    packed: 793_000,
     unpacked: 16_950_000,
     entries: 403,
   },


### PR DESCRIPTION
## Summary

- add public V6 helpers to encode and decode the 721 tiers hook's ruleset metadata
- preserve unrelated app-specific bits when setting or clearing transfer and reserve-mint pauses
- document the two-part transfer guard: a pausable tier plus an active ruleset pause
- reject metadata outside the protocol's 14-bit app-specific field
- add a patch changeset for `@bananapus/nana-sdk-core`

## Verification

- `npm run check`
- 355 core tests and 127 React tests pass with coverage
- adversarial tests cover unknown-bit preservation, independent flag clearing, invalid integers, and the maximum 14-bit value